### PR TITLE
Allow local OSV ingestion from the command line.

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -77,35 +77,26 @@ func main() {
 	}
 
 	// Determine sources based on flags
-	var sources []*source.Source
+	sources := c.Sources
 	if *sourceFlag != "" {
-		// Attempt to find an existing source
-		var src *source.Source
-		for _, s := range c.Sources {
-			if s.ID == *sourceFlag {
-				src = s
-				break
-			}
+		src := c.GetSource(*sourceFlag)
+		if src == nil && *localDirFlag == "" {
+			log.Fatalf("Unknown source: %s", *sourceFlag)
 		}
-		// Override the source bucket and prefix with a file:// handler so the
-		// local files are consumed instead.
 		if *localDirFlag != "" {
+			// We have a path, so if there is no source we create one.
 			if src == nil {
-				// For local files tolerate the non-existance of a source.
 				src = &source.Source{
 					ID:              *sourceFlag,
 					LookbackEntries: 0,
 				}
 			}
+			// Override the source bucket and prefix with a file:// handler so the
+			// local files are consumed instead.
 			src.Bucket = fmt.Sprintf("file://%s", lp)
 			src.Prefix = ""
 		}
-		if src == nil {
-			log.Fatalf("Unknown source %s", *sourceFlag)
-		}
-		sources = append(sources, src)
-	} else {
-		sources = c.Sources
+		sources = []*source.Source{src}
 	}
 
 	log.Printf("Using config: id prefix=%s, malicious=%s, false positives=%s, sources=%d", c.IDPrefix, c.MaliciousPath, c.FalsePositivePath, len(sources))

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/google/renameio"
+	_ "gocloud.dev/blob/fileblob"
 	_ "gocloud.dev/blob/gcsblob"
 	_ "gocloud.dev/blob/s3blob"
 
@@ -41,13 +42,31 @@ var tempDir string
 func main() {
 	configFlag := flag.String("config", "", "the filepath to the YAML config file")
 	startKeysFlag := flag.String("start-keys", "", "the filepath to a YAML file containing the keys to start from")
+	sourceFlag := flag.String("source", "", "ingest files for the specified source only")
+	localDirFlag := flag.String("dir", "", "ingest OSV reports from the given local dir. Requires -source.")
 	flag.Parse()
 
 	if *configFlag == "" {
 		log.Fatalf("-config flag is required")
 	}
 
-	// read sources from config
+	if *localDirFlag != "" && *sourceFlag == "" {
+		log.Fatalf("-dir requires -source to be set")
+	}
+
+	lp, err := filepath.Abs(*localDirFlag)
+	if err != nil {
+		log.Fatalf("Failed finding absolute path of %s: %v", *localDirFlag, err)
+	}
+	if s, err := os.Stat(lp); os.IsNotExist(err) {
+		log.Fatalf("-dir %s does not exist", *localDirFlag)
+	} else if err != nil {
+		log.Fatalf("-dir %s failed to stat: %v", *localDirFlag, err)
+	} else if !s.IsDir() {
+		log.Fatalf("-dir %s is not a directory", *localDirFlag)
+	}
+
+	// Read sources from config
 	configFile, err := os.Open(*configFlag)
 	if err != nil {
 		log.Fatalf("Failed to open config file %s: %v", *configFlag, err)
@@ -57,7 +76,39 @@ func main() {
 		log.Fatalf("Failed reading config: %v", err)
 	}
 
-	log.Printf("Using config: id prefix=%s, malicious=%s, false positives=%s, sources=%d", c.IDPrefix, c.MaliciousPath, c.FalsePositivePath, len(c.Sources))
+	// Determine sources based on flags
+	var sources []*source.Source
+	if *sourceFlag != "" {
+		// Attempt to find an existing source
+		var src *source.Source
+		for _, s := range c.Sources {
+			if s.ID == *sourceFlag {
+				src = s
+				break
+			}
+		}
+		// Override the source bucket and prefix with a file:// handler so the
+		// local files are consumed instead.
+		if *localDirFlag != "" {
+			if src == nil {
+				// For local files tolerate the non-existance of a source.
+				src = &source.Source{
+					ID:              *sourceFlag,
+					LookbackEntries: 0,
+				}
+			}
+			src.Bucket = fmt.Sprintf("file://%s", lp)
+			src.Prefix = ""
+		}
+		if src == nil {
+			log.Fatalf("Unknown source %s", *sourceFlag)
+		}
+		sources = append(sources, src)
+	} else {
+		sources = c.Sources
+	}
+
+	log.Printf("Using config: id prefix=%s, malicious=%s, false positives=%s, sources=%d", c.IDPrefix, c.MaliciousPath, c.FalsePositivePath, len(sources))
 
 	keys, err := loadStartKeys(*startKeysFlag)
 	if err != nil {
@@ -78,7 +129,7 @@ func main() {
 	}()
 
 	ctx := context.Background()
-	for _, s := range c.Sources {
+	for _, s := range sources {
 		end, err := ingestReports(ctx, s, c, keys.Get(s.ID))
 		if err != nil {
 			// Abort here since the repo is now in a dirty state.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,17 @@ func (c *Config) Paths() []string {
 	}
 }
 
+// GetSource looks up a given source by its ID and returns it if it exists,
+// otherwise nil is returned.
+func (c *Config) GetSource(id string) *source.Source {
+	for _, s := range c.Sources {
+		if s.ID == id {
+			return s
+		}
+	}
+	return nil
+}
+
 func ReadYAML(r io.Reader) (*Config, error) {
 	dec := yaml.NewDecoder(r)
 	var c *Config


### PR DESCRIPTION
Adds -source and -dir flags that allow someone to ingest OSV from a local directory.

`-source` can be a source in the config, or, if `-dir` is specified, it can be arbitrary.

If `-dir` is set `-source` must be set as well.

Local directory ingestion uses gocloud's fileblob to support ingestion.