### PR TITLE
Some minor changes to improve the automation

### DIFF
--- a/cmd/validate/main.go
+++ b/cmd/validate/main.go
@@ -29,6 +29,11 @@ import (
 	"github.com/ossf/malicious-packages/internal/reportio"
 )
 
+const (
+	filenameReadme = "README.md"
+	validExt       = ".json"
+)
+
 var validIDRe = regexp.MustCompile(`^([A-Z]+)-[0-9]{4}-[0-9]+$`)
 
 func main() {
@@ -78,6 +83,10 @@ func validateBase(basePath, idPrefix string) error {
 		if filepath.Base(path)[0] == '.' {
 			return nil
 		}
+		// Skip readme files
+		if filepath.Base(path) == filenameReadme {
+			return nil
+		}
 
 		return validateReport(path, basePath, idPrefix)
 	}))
@@ -119,6 +128,11 @@ func validateReport(reportPath, basePath, idPrefix string) error {
 	}
 	if wantPath != gotPath {
 		return fmt.Errorf("report path %s does not match expected path %s", gotPath, wantPath)
+	}
+
+	// Ensure the extension is valid.
+	if ext != validExt {
+		return fmt.Errorf("report filename %s does not end with %s", basename, validExt)
 	}
 
 	// TODO: add "withdrawn" check for files in the false positives directory.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/storage v1.30.1
 	github.com/aws/aws-sdk-go v1.44.290
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.35.0
-	github.com/google/osv-scanner v1.3.3
+	github.com/google/osv-scanner v1.3.5
 	github.com/google/renameio v1.0.1
 	gocloud.dev v0.30.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1

--- a/go.sum
+++ b/go.sum
@@ -1349,6 +1349,8 @@ github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdf
 github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/osv-scanner v1.3.3 h1:CeMeaCHPKx1jWb5b1ksTA3YOt7SNWjjW7tFltK6FOFU=
 github.com/google/osv-scanner v1.3.3/go.mod h1:kDFfINeXZDv/q5ZnNzIkMzi5X92INdMz1ohJsq9Z1eM=
+github.com/google/osv-scanner v1.3.5 h1:c0Qysr565PEWouwm48QEY5GyS3tfgcT4aKqjOUTqGqU=
+github.com/google/osv-scanner v1.3.5/go.mod h1:4SNp5Uz1X4tFjBecqtTV/3KcmCBRaQ3haUMAJuD1ij0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=

--- a/internal/report/details.go
+++ b/internal/report/details.go
@@ -24,11 +24,11 @@ import (
 const (
 	// detailHeader is the delimiter that sits between details provided by
 	// contributors (above) and the details included from the origins (below).
-	detailHeader = "\n##= Per source details. Do not edit below this line. =##\n"
+	detailHeader = "\n---\n_-= Per source details. Do not edit below this line.=-_\n"
 
 	// detailSectionHeader precedes each detail section indicating which source
 	// and origin the details were included from.
-	detailSectionHeader = "\n###= Source: %s (%s) =###\n"
+	detailSectionHeader = "\n## Source: %s (%s)\n"
 
 	// detailSourceMatchIdx is the index in the match for detailSectionHeaderRE
 	// for the source submatch.
@@ -41,7 +41,7 @@ const (
 
 // detailSectionHeaderRE is used to find the position of each section and
 // extract the source information from it.
-var detailSectionHeaderRE = regexp.MustCompile("(?s)\n###= Source: ([a-z0-9-]+) \\(([a-zA-Z0-9]+)\\) =###\n")
+var detailSectionHeaderRE = regexp.MustCompile("(?s)\n## Source: ([a-z0-9-]+) \\(([a-zA-Z0-9]+)\\)\n")
 
 // RawDetails returns the raw, unparsed, details of the OSV report.
 func (r *Report) RawDetails() string {

--- a/internal/report/details_test.go
+++ b/internal/report/details_test.go
@@ -50,7 +50,7 @@ func TestParseDetails_EmptyNoOrigins(t *testing.T) {
 }
 
 func TestParseDetails_EmptyOneHeader(t *testing.T) {
-	r := reportWithDetail(`\n##= Per source details. Do not edit below this line. =##\n`)
+	r := reportWithDetail(`\n---\n_-= Per source details. Do not edit below this line.=-_\n`)
 	gotUser, gotSources, err := r.ParseDetails()
 	if err != nil {
 		t.Fatalf("ParseDetails() = %v; want no error", err)
@@ -64,7 +64,7 @@ func TestParseDetails_EmptyOneHeader(t *testing.T) {
 }
 
 func TestParseDetails_TwoHeaders(t *testing.T) {
-	r := reportWithDetail(`hello\n##= Per source details. Do not edit below this line. =##\nworld\n##= Per source details. Do not edit below this line. =##\n!`)
+	r := reportWithDetail(`hello\n\n---\n_-= Per source details. Do not edit below this line.=-_\nworld\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n!`)
 	_, _, err := r.ParseDetails()
 	if err == nil || !errors.Is(err, report.ErrInvalidDetails) {
 		t.Fatalf("ParseDetails() = %v; want %v", err, report.ErrInvalidDetails)
@@ -87,7 +87,7 @@ func TestParseDetails_NoHeader(t *testing.T) {
 }
 
 func TestParseDetails_WithHeader(t *testing.T) {
-	r := reportWithDetail(`here is an\namazing\nreport\n\n##= Per source details. Do not edit below this line. =##\n`)
+	r := reportWithDetail(`here is an\namazing\nreport\n\n---\n_-= Per source details. Do not edit below this line.=-_\n`)
 	wantUser := "here is an\namazing\nreport"
 	gotUser, gotSources, err := r.ParseDetails()
 	if err != nil {
@@ -102,7 +102,7 @@ func TestParseDetails_WithHeader(t *testing.T) {
 }
 
 func TestParseDetails_InvalidSourceSection(t *testing.T) {
-	r := reportWithDetail(`user contributed report\n  ...\n\n##= Per source details. Do not edit below this line. =##\n\ninvalid`)
+	r := reportWithDetail(`user contributed report\n  ...\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\ninvalid`)
 	_, _, err := r.ParseDetails()
 	if err == nil || !errors.Is(err, report.ErrInvalidDetails) {
 		t.Fatalf("ParseDetails() = %v; want %v", err, report.ErrInvalidDetails)
@@ -110,7 +110,7 @@ func TestParseDetails_InvalidSourceSection(t *testing.T) {
 }
 
 func TestParseDetails_Sources_NoOrigin(t *testing.T) {
-	r := reportWithDetail(`user contributed report\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\n`)
+	r := reportWithDetail(`user contributed report\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\n`)
 	_, _, err := r.ParseDetails()
 	if err == nil || !errors.Is(err, report.ErrInvalidDetails) {
 		t.Fatalf("ParseDetails() = %v; want %v", err, report.ErrInvalidDetails)
@@ -118,7 +118,7 @@ func TestParseDetails_Sources_NoOrigin(t *testing.T) {
 }
 
 func TestParseDetails_Sources_WrongOrigin(t *testing.T) {
-	r := reportWithDetail(`user contributed report\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\n`)
+	r := reportWithDetail(`user contributed report\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\n`)
 	r.AddOrigin("test-source", "01234567")
 	_, _, err := r.ParseDetails()
 	if err == nil || !errors.Is(err, report.ErrInvalidDetails) {
@@ -127,7 +127,7 @@ func TestParseDetails_Sources_WrongOrigin(t *testing.T) {
 }
 
 func TestParseDetails_Sources_OneEmpty(t *testing.T) {
-	r := reportWithDetail(`user contributed report\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\n`)
+	r := reportWithDetail(`user contributed report\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\n`)
 	o := r.AddOrigin("test-source", "deadbeef")
 	wantUser := "user contributed report"
 	wantSources := map[*report.OriginRef]string{
@@ -146,7 +146,7 @@ func TestParseDetails_Sources_OneEmpty(t *testing.T) {
 }
 
 func TestParseDetails_Sources_Single(t *testing.T) {
-	r := reportWithDetail(`user contributed report\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\n\nthis\nis a\ntest.   \n`)
+	r := reportWithDetail(`user contributed report\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\n\nthis\nis a\ntest.   \n`)
 	o := r.AddOrigin("test-source", "deadbeef")
 	wantUser := "user contributed report"
 	wantSources := map[*report.OriginRef]string{
@@ -165,7 +165,7 @@ func TestParseDetails_Sources_Single(t *testing.T) {
 }
 
 func TestParseDetails_Sources_Two(t *testing.T) {
-	r := reportWithDetail(`user contributed report\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\nsource one\n\n###= Source: another-test-source (abcdef123) =###\n\nsource two  \n\n`)
+	r := reportWithDetail(`user contributed report\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\nsource one\n\n## Source: another-test-source (abcdef123)\n\nsource two  \n\n`)
 	o1 := r.AddOrigin("test-source", "deadbeef")
 	o2 := r.AddOrigin("another-test-source", "abcdef123")
 	wantUser := "user contributed report"
@@ -186,7 +186,7 @@ func TestParseDetails_Sources_Two(t *testing.T) {
 }
 
 func TestParseDetails_Sources_TwoOneEmpty(t *testing.T) {
-	r := reportWithDetail(`user contributed report\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\n\n###= Source: another-test-source (abcdef123) =###\n\nsource two  \n\n`)
+	r := reportWithDetail(`user contributed report\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\n\n## Source: another-test-source (abcdef123)\n\nsource two  \n\n`)
 	o1 := r.AddOrigin("test-source", "deadbeef")
 	o2 := r.AddOrigin("another-test-source", "abcdef123")
 	wantUser := "user contributed report"
@@ -209,7 +209,7 @@ func TestParseDetails_Sources_TwoOneEmpty(t *testing.T) {
 func TestSetDetails_Empty(t *testing.T) {
 	r := reportWithDetail("")
 	r.SetDetails("")
-	want := "\n##= Per source details. Do not edit below this line. =##\n"
+	want := "\n---\n_-= Per source details. Do not edit below this line.=-_\n"
 	if got := r.RawDetails(); got != want {
 		t.Errorf("RawDetails() = %v; want %v", got, want)
 	}
@@ -218,7 +218,7 @@ func TestSetDetails_Empty(t *testing.T) {
 func TestSetDetails_UserContributionOnly(t *testing.T) {
 	r := reportWithDetail("")
 	r.SetDetails("    this\nis a\nreport.   \n\n")
-	want := "this\nis a\nreport.\n\n##= Per source details. Do not edit below this line. =##\n"
+	want := "this\nis a\nreport.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n"
 	if got := r.RawDetails(); got != want {
 		t.Errorf("RawDetails() = %v; want %v", got, want)
 	}
@@ -230,7 +230,7 @@ func TestSetDetails_SingleSource(t *testing.T) {
 	r.SetDetails("user contribution", map[*report.OriginRef]string{
 		o: "source one",
 	})
-	want := "user contribution\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\nsource one\n"
+	want := "user contribution\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\nsource one\n"
 	if got := r.RawDetails(); got != want {
 		t.Errorf("RawDetails() = %v; want %v", got, want)
 	}
@@ -245,7 +245,7 @@ func TestSetDetails_TwoSources(t *testing.T) {
 	}, map[*report.OriginRef]string{
 		o2: "source two",
 	})
-	want := "user contribution\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: another-test-source (abcdef123) =###\nsource two\n\n###= Source: test-source (deadbeef) =###\nsource one\n"
+	want := "user contribution\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: another-test-source (abcdef123)\nsource two\n\n## Source: test-source (deadbeef)\nsource one\n"
 	if got := r.RawDetails(); got != want {
 		t.Errorf("RawDetails() = %v; want %v", got, want)
 	}
@@ -260,7 +260,7 @@ func TestSetDetails_TwoSourcesOneEmpty(t *testing.T) {
 	}, map[*report.OriginRef]string{
 		o2: "source two",
 	})
-	want := "user contribution\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: another-test-source (abcdef123) =###\nsource two\n"
+	want := "user contribution\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: another-test-source (abcdef123)\nsource two\n"
 	if got := r.RawDetails(); got != want {
 		t.Errorf("RawDetails() = %v; want %v", got, want)
 	}
@@ -277,7 +277,7 @@ func TestSetDetails_SameSourceChooseLongest(t *testing.T) {
 		o1: "this report is longer",
 		o2: "this is a report",
 	})
-	want := "user contribution\n\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-source (deadbeef) =###\nthis report is longer\n"
+	want := "user contribution\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-source (deadbeef)\nthis report is longer\n"
 	if got := r.RawDetails(); got != want {
 		t.Errorf("RawDetails() = %v; want %v", got, want)
 	}

--- a/internal/report/merge.go
+++ b/internal/report/merge.go
@@ -55,8 +55,7 @@ func (r *Report) Merge(other *Report) error {
 	r.raw.Credits = combineCredits(r.raw.Credits, other.raw.Credits)
 	r.raw.References = mergeSlices(r.raw.References, other.raw.References)
 	r.raw.Aliases = mergeSlices(r.raw.Aliases, other.raw.Aliases)
-	//nolint:gocritic
-	//r.raw.Related = mergeSlices(r.raw.Related, other.raw.Related) // uncomment when osv-scanner is released
+	r.raw.Related = mergeSlices(r.raw.Related, other.raw.Related)
 	r.raw.Severity = nil
 
 	// Description merging.

--- a/internal/report/merge_test.go
+++ b/internal/report/merge_test.go
@@ -321,7 +321,7 @@ func TestMerge_CreditsContactMerge(t *testing.T) {
 
 func TestMerge_DetailsParseError(t *testing.T) {
 	r := testReport(models.EcosystemNPM, "example")
-	r.Vuln().Details = "\n##= Per source details. Do not edit below this line. =##\n\n##= Per source details. Do not edit below this line. =##\n"
+	r.Vuln().Details = "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n---\n_-= Per source details. Do not edit below this line.=-_\n"
 	other := testReport(models.EcosystemNPM, "example")
 
 	if err := r.Merge(other); err == nil || !errors.Is(err, report.ErrMergeFailure) {

--- a/internal/report/merge_test.go
+++ b/internal/report/merge_test.go
@@ -204,6 +204,23 @@ func TestMerge_Aliases(t *testing.T) {
 	}
 }
 
+func TestMerge_Related(t *testing.T) {
+	r := testReport(models.EcosystemNPM, "example")
+	r.Vuln().Related = []string{"z", "b", "c"}
+	other := testReport(models.EcosystemNPM, "example")
+	other.Vuln().Related = []string{"b", "c", "d"}
+
+	want := []string{"z", "b", "c", "d"}
+
+	if err := r.Merge(other); err != nil {
+		t.Fatalf("Merge() = %v; want no error", err)
+	}
+
+	if got := r.Vuln().Related; !slices.Equal(got, want) {
+		t.Fatalf("Related = %v; want %v", got, want)
+	}
+}
+
 func TestMerge_References(t *testing.T) {
 	ref1 := models.Reference{
 		Type: models.ReferenceAdvisory,

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -175,7 +175,7 @@ func TestNormalize_Origin_DetailsChanged(t *testing.T) {
 		t.Fatalf("Normalize() = %v; want no error", err)
 	}
 
-	want := "\n##= Per source details. Do not edit below this line. =##\n\n###= Source: test-origin (deadbeef) =###\nplease move\nmy details\n"
+	want := "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: test-origin (deadbeef)\nplease move\nmy details\n"
 	if got := r.Vuln().Details; got != want {
 		t.Errorf("Details = %v; want %v", got, want)
 	}

--- a/malicious/README.md
+++ b/malicious/README.md
@@ -1,0 +1,3 @@
+# OSV Reports for Malicious Packages
+
+This directory contains all the OSV reports for malicious packages.

--- a/withdrawn/README.md
+++ b/withdrawn/README.md
@@ -1,0 +1,5 @@
+# Withdrawn OSV Reports for Malicious Packages
+
+This directory contains OSV reports for malicious packages that have been
+withdrawn because they are false positives, or otherwise incorrectly assigned to
+non-malicious packages.


### PR DESCRIPTION
1. allow README.md files to be present in the `malicious` and `withdrawn` paths
2. validate that OSV files end in `.json`
3. bump the osv-scanner version and support merging of the `related` field
4. update the details headers so they look good when rendered as markdown
5. add initial README.md files to `malicious` and `withdrawn` - this stops the id allocate error