### PR TITLE
Small tweaks to prepare for more ingestion

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -157,6 +157,9 @@ func ingestReports(ctx context.Context, s *source.Source, c *config.Config, star
 			return fmt.Errorf("failed to validate destination: %w", err)
 		}
 
+		// Ensure the incoming report does not have an ID
+		r.StripID()
+
 		// Check if the origin has already been ingested.
 		if ok, err := reportio.OriginExistsInPaths(path, c.Paths(), s.ID, shasum); err != nil {
 			return fmt.Errorf("duplicate detection failed: %w", err)

--- a/cmd/validate/main.go
+++ b/cmd/validate/main.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	filenameReadme = "README.md"
-	validExt       = ".json"
+	validExt = ".json"
 )
 
 var validIDRe = regexp.MustCompile(`^([A-Z]+)-[0-9]{4}-[0-9]+$`)
@@ -76,15 +75,7 @@ func validateBase(basePath, idPrefix string) error {
 		} else if err != nil {
 			return err
 		}
-		if info.IsDir() {
-			return nil
-		}
-		// Skip dot files
-		if filepath.Base(path)[0] == '.' {
-			return nil
-		}
-		// Skip readme files
-		if filepath.Base(path) == filenameReadme {
+		if !reportio.IsPossibleReport(info.Name(), info.Type()) {
 			return nil
 		}
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -135,8 +135,21 @@ func (r *Report) Path() string {
 	return filepath.Join(cleanEcosystem(r.Ecosystem), strings.ToLower(r.Name))
 }
 
+// ID returns the ID for the report.
+//
+// If no ID has been assigned the value will be the empty string.
 func (r *Report) ID() string {
 	return r.raw.ID
+}
+
+// StripID removes the ID for the report.
+func (r *Report) StripID() {
+	r.raw.ID = ""
+}
+
+// IsWithdrawn returns whether or not the report has been withdrawn.
+func (r *Report) IsWithdrawn() bool {
+	return !r.raw.Withdrawn.IsZero()
 }
 
 func cleanEcosystem(in string) string {

--- a/internal/reportio/reportio_test.go
+++ b/internal/reportio/reportio_test.go
@@ -15,6 +15,7 @@
 package reportio_test
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/ossf/malicious-packages/internal/reportio"
@@ -61,6 +62,43 @@ func TestValidatePath_Invalid(t *testing.T) {
 			err := reportio.ValidatePath(test)
 			if err == nil {
 				t.Error("ValidatePath() = nil; want an error")
+			}
+		})
+	}
+}
+
+func TestIsPossibleReport(t *testing.T) {
+	tests := []struct {
+		name string
+		mode fs.FileMode
+		want bool
+	}{
+		{
+			name: "MAL-1234-1.json",
+			mode: 0,
+			want: true,
+		},
+		{
+			name: "foobar.ext",
+			mode: 0,
+			want: true,
+		},
+		{
+			name: "README.md",
+			mode: 0,
+			want: false,
+		},
+		{
+			name: "subdir",
+			mode: fs.ModeDir,
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := reportio.IsPossibleReport(test.name, test.mode)
+			if got != test.want {
+				t.Fatalf("IsPossibleReport() = %v, want %v", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
- improve the filtering of directory entries so that it applies to validation, and preprocessing
- strip IDs during ingest to ensure the preprocess phase works correctly
- add initial handling of withdrawn
    - ignore new reports that are already withdrawn
    - fail when encountering a withdrawn report