### PR TITLE
Add "id" and "modified_time" to origin for more ways to dedupe.

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -157,15 +157,6 @@ func ingestReports(ctx context.Context, s *source.Source, c *config.Config, star
 			return fmt.Errorf("failed to validate destination: %w", err)
 		}
 
-		// If the source is asking for the ID to be aliased, then copy it into
-		// the aliases section.
-		if s.AliasID {
-			r.AliasID()
-		}
-
-		// Ensure the incoming report does not have an ID.
-		r.StripID()
-
 		// Check if the origin has already been ingested.
 		if ok, err := reportio.OriginExistsInPaths(path, c.Paths(), s.ID, shasum); err != nil {
 			return fmt.Errorf("duplicate detection failed: %w", err)
@@ -177,6 +168,15 @@ func ingestReports(ctx context.Context, s *source.Source, c *config.Config, star
 		// Add the origin to the report so we can de-dupe in the future and
 		// track where and when the report was ingested.
 		r.AddOrigin(s.ID, shasum)
+
+		// If the source is asking for the ID to be aliased, then copy it into
+		// the aliases section.
+		if s.AliasID {
+			r.AliasID()
+		}
+
+		// Ensure the incoming report does not have an ID.
+		r.StripID()
 
 		// Prepare the destination path, creating it if needed.
 		dest := filepath.Clean(filepath.Join(c.MaliciousPath, path))

--- a/internal/report/origin.go
+++ b/internal/report/origin.go
@@ -23,11 +23,13 @@ import (
 const originRefKey = "malicious-packages-origins"
 
 type OriginRef struct {
-	Source     string         `json:"source"`
-	SHASum     string         `json:"sha256"`
-	ImportTime time.Time      `json:"import_time"`
-	Ranges     []models.Range `json:"ranges,omitempty"`
-	Versions   []string       `json:"versions,omitempty"`
+	Source       string         `json:"source"`
+	SHASum       string         `json:"sha256"`
+	ImportTime   time.Time      `json:"import_time"`
+	ID           string         `json:"id,omitempty"`
+	ModifiedTime time.Time      `json:"modified_time"`
+	Ranges       []models.Range `json:"ranges,omitempty"`
+	Versions     []string       `json:"versions,omitempty"`
 }
 
 func (r *Report) getOrigin(sourceID, shasum string) *OriginRef {
@@ -45,11 +47,13 @@ func (r *Report) HasOrigin(sourceID, shasum string) bool {
 
 func (r *Report) AddOrigin(sourceID, shasum string) *OriginRef {
 	ref := &OriginRef{
-		Source:     sourceID,
-		SHASum:     shasum,
-		ImportTime: time.Now().UTC(),
-		Ranges:     r.raw.Affected[0].Ranges,
-		Versions:   r.raw.Affected[0].Versions,
+		Source:       sourceID,
+		SHASum:       shasum,
+		ImportTime:   time.Now().UTC(),
+		ModifiedTime: r.raw.Modified.UTC(),
+		ID:           r.raw.ID,
+		Ranges:       r.raw.Affected[0].Ranges,
+		Versions:     r.raw.Affected[0].Versions,
 	}
 	r.origins = append(r.origins, ref)
 	return ref


### PR DESCRIPTION
If we are ingesting a database with IDs assigned, that may modified the original OSV, to allow us to detect if the original OSV has change we can use the ID + modified time to see if the update should be included or ignored.

This makes it possible to distinguish between a change that may cause the SHA256 sum to change but is otherwise unchanged VS a change with updated content.