### PR TITLE
Use `pipenv run` instead of `pipenv shell`

### DIFF
--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -31,7 +31,7 @@ jobs:
         go-version: "1.20"
     - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: pipenv
         cache-dependency-path: osv-schema/tools/ghsa/Pipfile.lock
 

--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -49,13 +49,13 @@ jobs:
         cd osv-schema/tools/ghsa
         mkdir OUT
         TIMESINCE=`python3 -c 'import datetime; dt=datetime.datetime.now(datetime.UTC)-datetime.timedelta(hours=48); print(dt.isoformat())'`
-        pipenv shell python dump_ghsa.py --token "${{ github.token }}" --query "classifications: [MALWARE] updatedSince: \"$TIMESINCE\"" OUT
+        pipenv run python dump_ghsa.py --token "${{ github.token }}" --query "classifications: [MALWARE] updatedSince: \"$TIMESINCE\"" OUT
 
     - name: Convert GHSA to OSV
       run: |
         cd osv-schema/tools/ghsa
         mkdir OSV
-        pipenv shell python convert_ghsa.py -o OSV OUT/*.json
+        pipenv run python convert_ghsa.py -o OSV OUT/*.json
 
     - name: Ingest OSV
       run: |


### PR DESCRIPTION
`pipenv shell` doesn't work because it expects an interactive TTY.