### PR TITLE
Add a hack to bypass a bug in GoCloud's anonymous GCS support.

### DIFF
--- a/.github/workflows/ingest-cloud.yml
+++ b/.github/workflows/ingest-cloud.yml
@@ -25,9 +25,17 @@ jobs:
       with:
         go-version: "1.20"
 
+    # gocloud has an issue where it requires an ADC file to work with GCS, even
+    # for anonymous requests. This change tricks the auth code into succeeding.
+    - name: GCP Credential Workaround
+      run: |
+        echo "{ 'type': 'service_account' }" >> .dummy_adc.json
+
     - name: Ingest OSV
       run: |
         go run ./cmd/ingest -config config/config.yaml -start-keys config/start-keys.yaml
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS: .dummy_adc.json
 
     - name: Prepare commit
       run: |

--- a/.github/workflows/ingest-cloud.yml
+++ b/.github/workflows/ingest-cloud.yml
@@ -29,7 +29,7 @@ jobs:
     # for anonymous requests. This change tricks the auth code into succeeding.
     - name: GCP Credential Workaround
       run: |
-        echo "{ 'type': 'service_account' }" >> .dummy_adc.json
+        echo "{ 'type': 'service_account' }" > .dummy_adc.json
 
     - name: Ingest OSV
       run: |


### PR DESCRIPTION
GoCloud's GCS blob implementation is meant to support anonymous access using an `access_id=-` parameter.

However, in the Lazy URL opener (https://github.com/google/go-cloud/blob/v0.33.0/blob/gcsblob/gcsblob.go#L153), `gcp.DefaultCredentials(ctx)` is always called, which results in an error when a credential file is not present.

This bug works around this by providing the `golang.org/x/oauth/google` library internally with the minimum JSON object required to successfully return a valid credential object.