### PR TITLE
Enable write in workflows again, as this appears to be required.

### DIFF
--- a/.github/workflows/assign-osv-ids.yml
+++ b/.github/workflows/assign-osv-ids.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read  # GH_TOKEN is used to push to the repository.
+      contents: write
 
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/ingest-cloud.yml
+++ b/.github/workflows/ingest-cloud.yml
@@ -16,7 +16,7 @@ jobs:
 
     permissions:
       actions: read
-      contents: read  # GH_TOKEN is used to push to the repository.
+      contents: write
 
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -15,7 +15,7 @@ jobs:
 
     permissions:
       actions: read
-      contents: read  # GH_TOKEN is used to push to the repository.
+      contents: write
 
     steps:
     - name: Checkout self


### PR DESCRIPTION
Even with PATs.