### PR TITLE
Fix domains that should have been urls in recent import of OSV.

### DIFF
--- a/malicious/pypi/aliababcloud-tea-openapi/MAL-2023-8351.json
+++ b/malicious/pypi/aliababcloud-tea-openapi/MAL-2023-8351.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/alibabacloud-ecs20180317/MAL-2023-8352.json
+++ b/malicious/pypi/alibabacloud-ecs20180317/MAL-2023-8352.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/alibabacloud-oss2/MAL-2023-8353.json
+++ b/malicious/pypi/alibabacloud-oss2/MAL-2023-8353.json
@@ -40,11 +40,11 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
+      "urls": [
         "https://api.aliyun-sdk-requests.xyz/tencent",
         "https://api.aliyun-sdk-requests.xyz/aliyun",
         "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
+        "https://tg.aliyun-sdk-requests.xyz/telegram"
       ]
     },
     "malicious-packages-origins": [

--- a/malicious/pypi/alibabacloud-vpc20180317/MAL-2023-8354.json
+++ b/malicious/pypi/alibabacloud-vpc20180317/MAL-2023-8354.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/alisdkcore/MAL-2023-8355.json
+++ b/malicious/pypi/alisdkcore/MAL-2023-8355.json
@@ -40,11 +40,11 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
+      "urls": [
         "https://api.aliyun-sdk-requests.xyz/tencent",
         "https://api.aliyun-sdk-requests.xyz/aliyun",
         "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
+        "https://tg.aliyun-sdk-requests.xyz/telegram"
       ]
     },
     "malicious-packages-origins": [

--- a/malicious/pypi/aliyun-oss2/MAL-2023-8356.json
+++ b/malicious/pypi/aliyun-oss2/MAL-2023-8356.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/arangodba/MAL-2023-8357.json
+++ b/malicious/pypi/arangodba/MAL-2023-8357.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/aws-consoler2/MAL-2023-8358.json
+++ b/malicious/pypi/aws-consoler2/MAL-2023-8358.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/aws-enumerate-iam/MAL-2023-8359.json
+++ b/malicious/pypi/aws-enumerate-iam/MAL-2023-8359.json
@@ -40,11 +40,11 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
+      "urls": [
         "https://api.aliyun-sdk-requests.xyz/tencent",
         "https://api.aliyun-sdk-requests.xyz/aliyun",
         "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
+        "https://tg.aliyun-sdk-requests.xyz/telegram"
       ]
     },
     "malicious-packages-origins": [

--- a/malicious/pypi/enumerate-iam-aws/MAL-2023-8361.json
+++ b/malicious/pypi/enumerate-iam-aws/MAL-2023-8361.json
@@ -40,11 +40,11 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
+      "urls": [
         "https://api.aliyun-sdk-requests.xyz/tencent",
         "https://api.aliyun-sdk-requests.xyz/aliyun",
         "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
+        "https://tg.aliyun-sdk-requests.xyz/telegram"
       ]
     },
     "malicious-packages-origins": [

--- a/malicious/pypi/enumerate-iam/MAL-2023-8360.json
+++ b/malicious/pypi/enumerate-iam/MAL-2023-8360.json
@@ -64,12 +64,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/python-alibabacloud-sdk-core/MAL-2023-8362.json
+++ b/malicious/pypi/python-alibabacloud-sdk-core/MAL-2023-8362.json
@@ -40,11 +40,11 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
+      "urls": [
         "https://api.aliyun-sdk-requests.xyz/tencent",
         "https://api.aliyun-sdk-requests.xyz/aliyun",
         "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
+        "https://tg.aliyun-sdk-requests.xyz/telegram"
       ]
     },
     "malicious-packages-origins": [

--- a/malicious/pypi/python-alibabacloud-tea-openapi/MAL-2023-8363.json
+++ b/malicious/pypi/python-alibabacloud-tea-openapi/MAL-2023-8363.json
@@ -40,11 +40,11 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
+      "urls": [
         "https://api.aliyun-sdk-requests.xyz/tencent",
         "https://api.aliyun-sdk-requests.xyz/aliyun",
         "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
+        "https://tg.aliyun-sdk-requests.xyz/telegram"
       ]
     },
     "malicious-packages-origins": [

--- a/malicious/pypi/python-aliyun-sdk-core/MAL-2023-8364.json
+++ b/malicious/pypi/python-aliyun-sdk-core/MAL-2023-8364.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/python-aliyun-sdk-ecs/MAL-2023-8365.json
+++ b/malicious/pypi/python-aliyun-sdk-ecs/MAL-2023-8365.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/python-aliyun-sdk-kms/MAL-2023-8366.json
+++ b/malicious/pypi/python-aliyun-sdk-kms/MAL-2023-8366.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/python-aliyun-sdk-rds/MAL-2023-8367.json
+++ b/malicious/pypi/python-aliyun-sdk-rds/MAL-2023-8367.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/python-cos-sdk-v5/MAL-2023-8368.json
+++ b/malicious/pypi/python-cos-sdk-v5/MAL-2023-8368.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/telethon2/MAL-2023-8369.json
+++ b/malicious/pypi/telethon2/MAL-2023-8369.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],

--- a/malicious/pypi/tencent-cloud-python-sdk/MAL-2023-8370.json
+++ b/malicious/pypi/tencent-cloud-python-sdk/MAL-2023-8370.json
@@ -40,11 +40,11 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
+      "urls": [
         "https://api.aliyun-sdk-requests.xyz/tencent",
         "https://api.aliyun-sdk-requests.xyz/aliyun",
         "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
+        "https://tg.aliyun-sdk-requests.xyz/telegram"
       ]
     },
     "malicious-packages-origins": [

--- a/malicious/pypi/tencentcloud-python-sdk/MAL-2023-8371.json
+++ b/malicious/pypi/tencentcloud-python-sdk/MAL-2023-8371.json
@@ -53,12 +53,6 @@
   ],
   "database_specific": {
     "iocs": {
-      "domains": [
-        "https://api.aliyun-sdk-requests.xyz/tencent",
-        "https://api.aliyun-sdk-requests.xyz/aliyun",
-        "https://api.aliyun-sdk-requests.xyz/aws",
-        "https://tg.aliyun-sdk-requests.xyz/telegram\""
-      ],
       "ips": [
         "119.8.26.163"
       ],


### PR DESCRIPTION
Checkmarx included the array correctly, so for their reports we remove the errant list of domains.

For the rest, the key is renamed, and the trailing '"' character is removed.