### PR TITLE
Bump the version of osv-schema to pick up the last_affected support for ghsa

### DIFF
--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         token: ${{ secrets.GH_TOKEN }}
         repository: ossf/osv-schema
-        ref: c2daa7514282ba34925e4dd8fb1177e78e3cf431
+        ref: 719ef525491260972fbec8679130052d4086711c
         path: osv-schema
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:


### PR DESCRIPTION
Fixes #458.