### PR TITLE
Add support for multiple prefixes per source.

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -91,10 +91,10 @@ func main() {
 					LookbackEntries: 0,
 				}
 			}
-			// Override the source bucket and prefix with a file:// handler so the
-			// local files are consumed instead.
+			// Override the source bucket and prefixes with a file:// handler so
+			// the local files are consumed instead.
 			src.Bucket = fmt.Sprintf("file://%s", lp)
-			src.Prefix = ""
+			src.Prefixes = []string{}
 		}
 		sources = []*source.Source{src}
 	}
@@ -121,12 +121,14 @@ func main() {
 
 	ctx := context.Background()
 	for _, s := range sources {
-		end, err := ingestReports(ctx, s, c, keys.Get(s.ID))
-		if err != nil {
-			// Abort here since the repo is now in a dirty state.
-			log.Fatalf("Failed to ingest reports for source %s: %v", s.ID, err) //nolint:gocritic
+		for _, prefix := range s.GetPrefixes() {
+			end, err := ingestReports(ctx, s, prefix, c, keys.Get(s.ID, prefix))
+			if err != nil {
+				// Abort here since the repo is now in a dirty state.
+				log.Fatalf("Failed to ingest reports for source %s: %v", s.ID, err) //nolint:gocritic
+			}
+			keys.Set(s.ID, prefix, end)
 		}
-		keys.Set(s.ID, end)
 	}
 
 	// Atomically write updated start keys...
@@ -135,10 +137,10 @@ func main() {
 	}
 }
 
-func ingestReports(ctx context.Context, s *source.Source, c *config.Config, start string) (string, error) {
-	log.Printf("[%s] Processing... (bucket: %s, prefix: %s)", s.ID, s.Bucket, s.Prefix)
+func ingestReports(ctx context.Context, s *source.Source, prefix string, c *config.Config, start string) (string, error) {
+	log.Printf("[%s] Processing... (bucket: %s, prefix: %s)", s.ID, s.Bucket, prefix)
 	saveCount := 0
-	end, err := sourceio.Walk(ctx, s, start, func(ctx context.Context, key string, rdr io.Reader) error {
+	end, err := sourceio.Walk(ctx, s, prefix, start, func(ctx context.Context, key string, rdr io.Reader) error {
 		// Generate a hash while we consume the report so we can detect duplicates.
 		h := sha256.New()
 		rdr = io.TeeReader(rdr, h)

--- a/cmd/ingest/sourceio/walk.go
+++ b/cmd/ingest/sourceio/walk.go
@@ -66,7 +66,7 @@ func beforeListFunc(start string) func(as func(interface{}) bool) error {
 // key with a reader for consuming the entry.
 //
 // If start is not empty, entries will be consumed from start.
-func Walk(ctx context.Context, s *source.Source, start string, walkFn func(ctx context.Context, key string, r io.Reader) error) (string, error) {
+func Walk(ctx context.Context, s *source.Source, prefix, start string, walkFn func(ctx context.Context, key string, r io.Reader) error) (string, error) {
 	// Ignore sources that have no bucket set.
 	if s.Bucket == "" {
 		return "", nil
@@ -93,7 +93,7 @@ func Walk(ctx context.Context, s *source.Source, start string, walkFn func(ctx c
 	}
 
 	iter := bkt.List(&blob.ListOptions{
-		Prefix:     s.Prefix,
+		Prefix:     prefix,
 		BeforeList: beforeListFunc(start),
 	})
 	for {

--- a/cmd/ingest/startkeys/startkeys.go
+++ b/cmd/ingest/startkeys/startkeys.go
@@ -21,17 +21,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// StartKeys maps each source ID to the key that ingestion will start from.
+// StartKeys maps each source ID and prefix to the key that ingestion will start
+// from.
 //
 // A nil value of StartKeys supports Get, Set and IsDirty, but have no effect.
 type StartKeys struct {
-	keys  map[string]string
+	keys  map[string]map[string]string
 	dirty bool
 }
 
 // New creates a new instance of StartKeys.
 func New() *StartKeys {
-	return &StartKeys{keys: make(map[string]string)}
+	return &StartKeys{keys: make(map[string]map[string]string)}
 }
 
 // ReadYAML populates the data from the supplied reader containing YAML content.
@@ -44,32 +45,38 @@ func (sk *StartKeys) ReadYAML(r io.Reader) error {
 	return nil
 }
 
-// Get returns the corresponding start key for the supplied ID. If the key is
-// not present an empty string will be returned.
+// Get returns the corresponding start key for the supplied id and prefix. If
+// the key is not present an empty string will be returned.
 //
-// An emptry string will also be returned for a nil StartKeys.
-func (sk *StartKeys) Get(id string) string {
+// An empty string will also be returned for a nil StartKeys.
+func (sk *StartKeys) Get(id, prefix string) string {
 	if sk == nil {
 		return ""
 	}
-	return sk.keys[id]
+	if k, ok := sk.keys[id]; ok {
+		return k[prefix]
+	}
+	return ""
 }
 
-// Set stores the key for the supplied ID. If the key results in a value changing
-// IsDirty() will return true.
+// Set stores the key for the supplied id and prefix. If the key results in a
+// value changing IsDirty() will return true.
 //
 // The function will no-op if StartKeys is nil.
-func (sk *StartKeys) Set(id, key string) {
+func (sk *StartKeys) Set(id, prefix, key string) {
 	if sk == nil {
 		return
 	}
 	if key == "" {
 		return
 	}
-	if sk.keys[id] == key {
+	if _, ok := sk.keys[id]; !ok {
+		sk.keys[id] = make(map[string]string)
+	}
+	if sk.keys[id][prefix] == key {
 		return
 	}
-	sk.keys[id] = key
+	sk.keys[id][prefix] = key
 	sk.dirty = true
 }
 

--- a/cmd/ingest/startkeys/startkeys_test.go
+++ b/cmd/ingest/startkeys/startkeys_test.go
@@ -31,16 +31,16 @@ func TestNew(t *testing.T) {
 func TestGet_Empty(t *testing.T) {
 	sk := startkeys.New()
 	want := ""
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", "a"); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 }
 
 func TestGet(t *testing.T) {
 	sk := startkeys.New()
-	sk.Set("dummy", "a/key")
+	sk.Set("dummy", "a", "a/key")
 	want := "a/key"
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", "a"); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 }
@@ -48,33 +48,33 @@ func TestGet(t *testing.T) {
 func TestGet_Nil(t *testing.T) {
 	var sk *startkeys.StartKeys
 	want := ""
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", "a"); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 }
 
 func TestSet_Nil(t *testing.T) {
 	var sk *startkeys.StartKeys
-	sk.Set("dummy", "another/key")
+	sk.Set("dummy", "a", "another/key")
 	want := ""
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", "a"); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 }
 
 func TestSet_EmptyKey(t *testing.T) {
 	sk := startkeys.New()
-	sk.Set("dummy", "and/another/key")
-	sk.Set("dummy", "")
+	sk.Set("dummy", "", "and/another/key")
+	sk.Set("dummy", "", "")
 	want := "and/another/key"
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", ""); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 }
 
 func TestIsDirty_Nil(t *testing.T) {
 	var sk *startkeys.StartKeys
-	sk.Set("dummy", "path/to/key")
+	sk.Set("dummy", "a", "path/to/key")
 	want := false
 	if got := sk.IsDirty(); got != want {
 		t.Errorf("IsDirty() = %v; want %v", got, want)
@@ -91,7 +91,7 @@ func TestIsDirty_New(t *testing.T) {
 
 func TestIsDirty_Set(t *testing.T) {
 	sk := startkeys.New()
-	sk.Set("dummy", "path/to/key")
+	sk.Set("dummy", "a", "path/to/key")
 	want := true
 	if got := sk.IsDirty(); got != want {
 		t.Errorf("IsDirty() = %v; want %v", got, want)
@@ -100,7 +100,7 @@ func TestIsDirty_Set(t *testing.T) {
 
 func TestIsDirty_EmptyKey(t *testing.T) {
 	sk := startkeys.New()
-	sk.Set("dummy", "")
+	sk.Set("dummy", "a", "")
 	want := false
 	if got := sk.IsDirty(); got != want {
 		t.Errorf("IsDirty() = %v; want %v", got, want)
@@ -110,13 +110,14 @@ func TestIsDirty_EmptyKey(t *testing.T) {
 func TestReadYAML_ReadOnly(t *testing.T) {
 	sk := startkeys.New()
 	err := sk.ReadYAML(bytes.NewBufferString(`
-dummy: path/to/key
+dummy:
+  path/: path/to/key
 `))
 	if err != nil {
 		t.Fatalf("ReadYAML() = %v; want no error", err)
 	}
 	want := "path/to/key"
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", "path/"); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 	if got := sk.IsDirty(); got != false {
@@ -127,14 +128,15 @@ dummy: path/to/key
 func TestReadYAML_ThenWrite(t *testing.T) {
 	sk := startkeys.New()
 	err := sk.ReadYAML(bytes.NewBufferString(`
-dummy: path/to/key
+dummy:
+ path/: path/to/key
 `))
 	if err != nil {
 		t.Fatalf("ReadYAML() = %v; want no error", err)
 	}
-	sk.Set("dummy", "new/key")
+	sk.Set("dummy", "path/", "new/key")
 	want := "new/key"
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", "path/"); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 	if got := sk.IsDirty(); got != true {
@@ -145,14 +147,15 @@ dummy: path/to/key
 func TestReadYAML_ThenWriteNoChange(t *testing.T) {
 	sk := startkeys.New()
 	err := sk.ReadYAML(bytes.NewBufferString(`
-dummy: path/to/key
+dummy:
+  path/: path/to/key
 `))
 	if err != nil {
 		t.Fatalf("ReadYAML() = %v; want no error", err)
 	}
-	sk.Set("dummy", "path/to/key")
+	sk.Set("dummy", "path/", "path/to/key")
 	want := "path/to/key"
-	if got := sk.Get("dummy"); got != want {
+	if got := sk.Get("dummy", "path/"); got != want {
 		t.Errorf("Get() = %v; want %v", got, want)
 	}
 	if got := sk.IsDirty(); got != false {
@@ -170,14 +173,15 @@ func TestReadYAML_Error(t *testing.T) {
 
 func TestWriteYAML(t *testing.T) {
 	sk := startkeys.New()
-	sk.Set("source1", "path/one")
-	sk.Set("source2", "path/two")
+	sk.Set("source1", "path/", "path/one")
+	sk.Set("source1", "alt/", "alt/one")
+	sk.Set("source2", "path/", "path/two")
 	var buf bytes.Buffer
 	err := sk.WriteYAML(&buf)
 	if err != nil {
 		t.Fatalf("WriteYAML() = %v; want no error", err)
 	}
-	want := "source1: path/one\nsource2: path/two\n"
+	want := "source1:\n    alt/: alt/one\n    path/: path/one\nsource2:\n    path/: path/two\n"
 	if got := buf.String(); got != want {
 		t.Errorf("WriteYaml wrote %#v; want %#v", got, want)
 	}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,8 @@ false-positive-path: "./osv/withdrawn/"
 sources:
 - id: "ossf-package-analysis"
   bucket: "gs://gosst-package-detection-osv?access_id=-"
-  prefix: "confident/"
   lookback-entries: 10
+  prefixes:
+  - "confident/"
 - id: "ghsa-malware"
   alias-id: true

--- a/config/start-keys.yaml
+++ b/config/start-keys.yaml
@@ -1,1 +1,2 @@
-ossf-package-analysis: confident/20240506/235822-pypi-multiconnections-2.34.23.json
+ossf-package-analysis:
+    confident/: confident/20240506/235822-pypi-multiconnections-2.34.23.json

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -28,11 +28,11 @@ var (
 )
 
 type Source struct {
-	ID              string `yaml:"id"`
-	Bucket          string `yaml:"bucket"`
-	Prefix          string `yaml:"prefix"`
-	LookbackEntries int    `yaml:"lookback-entries"`
-	AliasID         bool   `yaml:"alias-id"`
+	ID              string   `yaml:"id"`
+	Bucket          string   `yaml:"bucket"`
+	Prefixes        []string `yaml:"prefixes"`
+	LookbackEntries int      `yaml:"lookback-entries"`
+	AliasID         bool     `yaml:"alias-id"`
 }
 
 func validateID(id string) error {
@@ -57,4 +57,11 @@ func (s *Source) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*s = Source(*raw)
 	return nil
+}
+
+func (s *Source) GetPrefixes() []string {
+	if len(s.Prefixes) == 0 {
+		return []string{""}
+	}
+	return s.Prefixes
 }


### PR DESCRIPTION
This allows for more diverse types of sources, such as when multiple streams of OSV files may be present in a single bucket under different prefixes.