### PR TITLE
Add version 4.1.2 of malicious package harthat-chain

### DIFF
--- a/osv/malicious/npm/harthat-chain/MAL-2024-7841.json
+++ b/osv/malicious/npm/harthat-chain/MAL-2024-7841.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2024-07-25T10:39:45Z",
+  "modified": "2024-07-30T00:15:00Z",
   "published": "2024-07-25T10:39:45Z",
   "schema_version": "1.5.0",
   "id": "MAL-2024-7841",
@@ -12,6 +12,7 @@
         "name": "harthat-chain"
       },
       "versions": [
+        "4.1.2",
         "4.2.3"
       ]
     }


### PR DESCRIPTION
According to data we have collected version 4.1.2 was also published about a day earlier than 4.2.3.
