### PR TITLE
Withdraw drata (npm) - MAL-2024-1398.

### DIFF
--- a/osv/withdrawn/npm/drata/MAL-2024-1398.json
+++ b/osv/withdrawn/npm/drata/MAL-2024-1398.json
@@ -1,6 +1,7 @@
 {
-  "modified": "2024-06-04T05:05:35Z",
+  "modified": "2024-08-29T04:29:00Z",
   "published": "2024-05-31T14:31:40Z",
+  "withdrawn": "2024-08-29T04:29:00Z",
   "schema_version": "1.5.0",
   "id": "MAL-2024-1398",
   "summary": "Malicious code in drata (npm)",


### PR DESCRIPTION
The package, while it connects to pipedream, didn't exfil any interesting data.


Fixes #593