### PR TITLE
Withdraw urlcon- advisory

### DIFF
--- a/osv/withdrawn/pypi/urlcon-/MAL-2024-10183.json
+++ b/osv/withdrawn/pypi/urlcon-/MAL-2024-10183.json
@@ -1,6 +1,7 @@
 {
-  "modified": "2024-10-16T14:53:26Z",
+  "modified": "2024-12-12T11:22:57Z",
   "published": "2024-10-16T14:53:26Z",
+  "withdrawn": "2024-12-12T11:22:57Z",
   "schema_version": "1.5.0",
   "id": "MAL-2024-10183",
   "summary": "Malicious code in urlcon- (PyPI)",


### PR DESCRIPTION
Hi, 

This PR is for withdrawing the `urlcon-` advisory as explained in [issue](https://github.com/ossf/malicious-packages/issues/703). Thanks!