### PR TITLE
Added reports for five malicious npm packages

### DIFF
--- a/osv/malicious/npm/4m-clean-shopify-app/MAL-0000-4m-clean-shopify-app.json
+++ b/osv/malicious/npm/4m-clean-shopify-app/MAL-0000-4m-clean-shopify-app.json
@@ -1,0 +1,29 @@
+{
+    "modified": "2025-01-02T12:13:56.000000Z",
+    "published": "2025-01-02T12:13:56.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in 4m-clean-shopify-app (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "4m-clean-shopify-app"
+            },
+            "versions": [
+		"9.0.0",
+		"9.0.1",
+		"9.0.4"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/create-shopify-web-app/MAL-0000-create-shopify-web-app.json
+++ b/osv/malicious/npm/create-shopify-web-app/MAL-0000-create-shopify-web-app.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-02T12:13:56.000000Z",
+    "published": "2025-01-02T12:13:56.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in create-shopify-web-app (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "create-shopify-web-app"
+            },
+            "versions": [
+		"9.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/forcechatter/MAL-0000-forcechatter.json
+++ b/osv/malicious/npm/forcechatter/MAL-0000-forcechatter.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-02T12:13:56.000000Z",
+    "published": "2025-01-02T12:13:56.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in forcechatter (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "forcechatter"
+            },
+            "versions": [
+		"99.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/semantic-release-dependencies/MAL-0000-semantic-release-dependencies.json
+++ b/osv/malicious/npm/semantic-release-dependencies/MAL-0000-semantic-release-dependencies.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-02T12:13:56.000000Z",
+    "published": "2025-01-02T12:13:56.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in semantic-release-dependencies (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "semantic-release-dependencies"
+            },
+            "versions": [
+		"9.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/swisscom-scaleio/MAL-0000-swisscom-scaleio.json
+++ b/osv/malicious/npm/swisscom-scaleio/MAL-0000-swisscom-scaleio.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-02T12:13:56.000000Z",
+    "published": "2025-01-02T12:13:56.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in swisscom-scaleio (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "swisscom-scaleio"
+            },
+            "versions": [
+		"9.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added reports for five malicious npm packages:
4m-clean-shopify-app, create-shopify-web-app, swisscom-scaleio, semantic-release-dependencies, forcechatter