### PR TITLE
Added reports for five malicious npm packages

### DIFF
--- a/osv/malicious/npm/aem-guides-wknd-app/MAL-0000-aem-guides-wknd-app.json
+++ b/osv/malicious/npm/aem-guides-wknd-app/MAL-0000-aem-guides-wknd-app.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-08T01:43:42.000000Z",
+    "published": "2025-01-08T01:43:42.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in aem-guides-wknd-app (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "aem-guides-wknd-app"
+            },
+            "versions": [
+		"3.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/electron-wix-msi-local/MAL-0000-electron-wix-msi-local.json
+++ b/osv/malicious/npm/electron-wix-msi-local/MAL-0000-electron-wix-msi-local.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-08T01:43:42.000000Z",
+    "published": "2025-01-08T01:43:42.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in electron-wix-msi-local (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "electron-wix-msi-local"
+            },
+            "versions": [
+		"4.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/jupyter-binding/MAL-0000-jupyter-binding.json
+++ b/osv/malicious/npm/jupyter-binding/MAL-0000-jupyter-binding.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-08T01:43:42.000000Z",
+    "published": "2025-01-08T01:43:42.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in jupyter-binding (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "jupyter-binding"
+            },
+            "versions": [
+		"1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/keeper-secrets-manager/MAL-0000-keeper-secrets-manager.json
+++ b/osv/malicious/npm/keeper-secrets-manager/MAL-0000-keeper-secrets-manager.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-08T01:43:42.000000Z",
+    "published": "2025-01-08T01:43:42.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in keeper-secrets-manager (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "keeper-secrets-manager"
+            },
+            "versions": [
+		"1.1.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/kiota-typescript/MAL-0000-kiota-typescript.json
+++ b/osv/malicious/npm/kiota-typescript/MAL-0000-kiota-typescript.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-08T01:43:42.000000Z",
+    "published": "2025-01-08T01:43:42.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in kiota-typescript (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "kiota-typescript"
+            },
+            "versions": [
+		"9.9.9"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added reports for five malicious npm packages:
aem-guides-wknd-app 
electron-wix-msi-local 
jupyter-binding
keeper-secrets-manager
kiota-typescript