### PR TITLE
Added reports for malware deploying npm packages marked-cs and marked-ps

### DIFF
--- a/osv/malicious/npm/marked-cs/MAL-0000-marked-cs.json
+++ b/osv/malicious/npm/marked-cs/MAL-0000-marked-cs.json
@@ -1,0 +1,39 @@
+{
+    "modified": "2025-01-12T04:49:52.000000Z",
+    "published": "2025-01-12T04:49:52.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Marked-cs npm package deploys malware",
+    "details": "This package deploys Windows gh0strat malware via VBScript",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "marked-cs"
+            },
+            "versions": [
+		"1.0.0",
+		"1.1.0",
+		"1.2.0",
+		"1.3.0",
+		"1.4.0",
+		"1.5.0",
+		"1.6.0",
+		"1.7.0",
+		"1.8.0",
+		"1.9.0",
+		"2.0.0",
+		"2.1.0",
+		"2.2.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/marked-ps/MAL-0000-marked-ps.json
+++ b/osv/malicious/npm/marked-ps/MAL-0000-marked-ps.json
@@ -3,7 +3,7 @@
     "published": "2025-01-12T04:49:52.000000Z",
     "schema_version": "1.5.0",
     "summary": "Marked-ps npm package deploys malware",
-    "details": "This package deploys Windows gh0strat malware via VBScript",
+    "details": "This package deploys Windows gh0strat malware via VBScript.",
     "affected": [
         {
             "package": {

--- a/osv/malicious/npm/marked-ps/MAL-0000-marked-ps.json
+++ b/osv/malicious/npm/marked-ps/MAL-0000-marked-ps.json
@@ -1,0 +1,34 @@
+{
+    "modified": "2025-01-12T04:49:52.000000Z",
+    "published": "2025-01-12T04:49:52.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Marked-ps npm package deploys malware",
+    "details": "This package deploys Windows gh0strat malware via VBScript",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "marked-ps"
+            },
+            "versions": [
+		"1.0.0",
+		"2.0.0",
+		"2.1.0",
+		"2.2.0",
+		"2.3.0",
+		"2.4.0",
+		"2.5.0",
+		"2.6.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added reports for two npm packages marked-cs and marked-ps that deploy the gh0strat stealer/implant