### PR TITLE
Added reports for 4 malicious npm packages

### DIFF
--- a/osv/malicious/npm/build-stuff/MAL-0000-build-stuff.json
+++ b/osv/malicious/npm/build-stuff/MAL-0000-build-stuff.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-13T22:55:41.000000Z",
+    "published": "2025-01-13T22:55:41.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in build-stuff (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "build-stuff"
+            },
+            "versions": [
+		"1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/gatsby-hampton-theme/MAL-0000-gatsby-hampton-theme.json
+++ b/osv/malicious/npm/gatsby-hampton-theme/MAL-0000-gatsby-hampton-theme.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-13T22:55:41.000000Z",
+    "published": "2025-01-13T22:55:41.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in gatsby-hampton-theme (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "gatsby-hampton-theme"
+            },
+            "versions": [
+		"1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/lambda-sns-dynatrace-sdk/MAL-0000-lambda-sns-dynatrace-sdk.json
+++ b/osv/malicious/npm/lambda-sns-dynatrace-sdk/MAL-0000-lambda-sns-dynatrace-sdk.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-13T22:55:41.000000Z",
+    "published": "2025-01-13T22:55:41.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in lambda-sns-dynatrace-sdk (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "lambda-sns-dynatrace-sdk"
+            },
+            "versions": [
+		"1.1.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/vscode-gestalt/MAL-0000-vscode-gestalt.json
+++ b/osv/malicious/npm/vscode-gestalt/MAL-0000-vscode-gestalt.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-01-13T22:55:41.000000Z",
+    "published": "2025-01-13T22:55:41.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in vscode-gestalt (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "vscode-gestalt"
+            },
+            "versions": [
+		"1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added reports for 4 malicious npm packages:
build-stuff
gatsby-hampton-theme
lambda-sns-dynatrace-sdk
vscode-gestalt