### PR TITLE
Remove the explicit token to use the per-run token so we can checkout repos during PRs.

### DIFF
--- a/.github/workflows/validate-osv.yml
+++ b/.github/workflows/validate-osv.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Checkout ossf/osv-schema
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
-        token: ${{ secrets.GH_TOKEN }}
         repository: ossf/osv-schema
         ref: ed713ef6511fa4113c89e25ea5e3da5291c6f05d
         path: osv-schema


### PR DESCRIPTION
This should fix validation breaking on PRs from external branches