### PR TITLE
Improve the dependabot config to lower toil.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,22 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    go-minor-updates:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "daily"
+    interval: weekly
+  open-pull-requests-limit: 10
+  groups:
+    actions-minor-updates:
+      applies-to: version-updates
+      update-types:
+        - minor
+        - patch


### PR DESCRIPTION
- weekly updates instead of daily
- minor and patch version only updates are grouped together

This means:

- security and major patches remain separate