### PR TITLE
Remove the ranges from nr-reports-core to match the malicious package explicitly.

### DIFF
--- a/osv/malicious/npm/nr-reports-core/MAL-2025-212.json
+++ b/osv/malicious/npm/nr-reports-core/MAL-2025-212.json
@@ -14,16 +14,6 @@
         "ecosystem": "npm",
         "name": "nr-reports-core"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
       "versions": [
         "1.1.1"
       ],


### PR DESCRIPTION
Fixes #799.