### PR TITLE
Update .golangci.yml to replace exportloopref with copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,12 @@ linters:
   enable:
     - asciicheck
     - bodyclose  # Temporarily disabled.
+    - copyloopvar
     #- depguard
     - dogsled
     #- errcheck  # Temporarily disabled.
     - errorlint
     - exhaustive
-    - exportloopref
     - gci
     #- gochecknoinits  # Temporarily disabled.
     #- gocognit  # Temporarily disabled.


### PR DESCRIPTION
This should fix the broken linter.