### PR TITLE
Added reports for 8 malicious npm packages

### DIFF
--- a/osv/malicious/npm/1password-sdk-examples/MAL-0000-1password-sdk-examples.json
+++ b/osv/malicious/npm/1password-sdk-examples/MAL-0000-1password-sdk-examples.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in 1password-sdk-examples (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "1password-sdk-examples"
+            },
+            "versions": [
+                "1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/charts-e2e/MAL-0000-charts-e2e.json
+++ b/osv/malicious/npm/charts-e2e/MAL-0000-charts-e2e.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in charts-e2e (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "charts-e2e"
+            },
+            "versions": [
+                "1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/com.adobe.cq.core.wcm.components.content/MAL-0000-com.adobe.cq.core.wcm.components.content.json
+++ b/osv/malicious/npm/com.adobe.cq.core.wcm.components.content/MAL-0000-com.adobe.cq.core.wcm.components.content.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in com.adobe.cq.core.wcm.components.content (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "com.adobe.cq.core.wcm.components.content"
+            },
+            "versions": [
+                "3.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/fgrttry565be/MAL-0000-fgrttry565be.json
+++ b/osv/malicious/npm/fgrttry565be/MAL-0000-fgrttry565be.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in fgrttry565be (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "fgrttry565be"
+            },
+            "versions": [
+                "1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/sample-notes-application/MAL-0000-sample-notes-application.json
+++ b/osv/malicious/npm/sample-notes-application/MAL-0000-sample-notes-application.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in sample-notes-application (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "sample-notes-application"
+            },
+            "versions": [
+                "1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/testdjhfyr76t47hfudhh/MAL-0000-testdjhfyr76t47hfudhh.json
+++ b/osv/malicious/npm/testdjhfyr76t47hfudhh/MAL-0000-testdjhfyr76t47hfudhh.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in testdjhfyr76t47hfudhh (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "testdjhfyr76t47hfudhh"
+            },
+            "versions": [
+                "1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/testing098765/MAL-0000-testing098765.json
+++ b/osv/malicious/npm/testing098765/MAL-0000-testing098765.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in testing098765 (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "testing098765"
+            },
+            "versions": [
+                "1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}

--- a/osv/malicious/npm/tstfde54545/MAL-0000-tstfde54545.json
+++ b/osv/malicious/npm/tstfde54545/MAL-0000-tstfde54545.json
@@ -1,0 +1,27 @@
+{
+    "modified": "2025-02-23T05:16:15.000000Z",
+    "published": "2025-02-23T05:16:15.000000Z",
+    "schema_version": "1.5.0",
+    "summary": "Malicious code in tstfde54545 (npm)",
+    "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+    "affected": [
+        {
+            "package": {
+                "ecosystem": "npm",
+                "name": "tstfde54545"
+            },
+            "versions": [
+                "1.0.0"
+            ]
+        }
+    ],
+    "credits": [
+        {
+            "name": "GitHax - Software Supply Chain Threat Intelligence",
+            "type": "FINDER",
+            "contact": [
+                "https://githax.com"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added reports for 8 malicious npm packages:
testdjhfyr76t47hfudhh
fgrttry565be
tstfde54545
1password-sdk-examples
sample-notes-application
testing098765
com.adobe.cq.core.wcm.components.content
charts-e2e