### PR TITLE
Add two more black spammer PyPI packages

### DIFF
--- a/osv/malicious/pypi/bsb-backup/MAL-0000-bsb-backup.json
+++ b/osv/malicious/pypi/bsb-backup/MAL-0000-bsb-backup.json
@@ -1,0 +1,42 @@
+{
+  "modified": "2025-03-24T10:27:00Z",
+  "published": "2025-03-24T10:27:00Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in bsb-backup (PyPI)",
+  "details": "This package decodes and executes a script during installation to set up a Telegram bot for device event monitoring. However, the code is obfuscated, making it difficult to comprehend and obscuring its true intent.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "bsb-backup",
+        "purl": "pkg:pypi/bsb-backup"
+      },
+      "versions": [
+        "2.0"
+      ]
+    }
+  ],
+  "credits": [
+    {
+      "name": "Oracle using Macaron",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/oracle/macaron"
+      ]
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "import_time": "2025-03-24T10:27:00Z",
+        "modified_time": "2025-03-24T10:27:00Z",
+        "sha256": "7c8850cc513318b8ede38268eed0fee01ba44c81087cd289294b63bada9f394c",
+        "source": "Oracle using Macaron",
+        "versions": [
+          "2.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/pypi/team-bsb-bot/MAL-0000-team-bsb-bot.json
+++ b/osv/malicious/pypi/team-bsb-bot/MAL-0000-team-bsb-bot.json
@@ -1,0 +1,42 @@
+{
+  "modified": "2025-03-24T10:27:00Z",
+  "published": "2025-03-24T10:27:00Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in team-bsb-bot (PyPI)",
+  "details": "This package appears to be part of a larger ecosystem acting as a placeholder for orchestrating interactions with other bsb malicious packages.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "team-bsb-bot",
+        "purl": "pkg:pypi/team-bsb-bot"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "credits": [
+    {
+      "name": "Oracle using Macaron",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/oracle/macaron"
+      ]
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "import_time": "2025-03-24T10:27:00Z",
+        "modified_time": "2025-03-24T10:27:00Z",
+        "sha256": "da5627aaacdf2bd8ab0ce2e469ea8635108e857776ed8766ee9df47c4b66aaa8",
+        "source": "Oracle using Macaron",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds two additional black spammer packages related to the ones reported in [#845](https://github.com/ossf/malicious-packages/pull/845). These packages were created under a different PyPI account and have since been removed by PyPI security.