### PR TITLE
Add tiger packages

### DIFF
--- a/osv/malicious/pypi/tig3r/MAL-0000-tig3r.json
+++ b/osv/malicious/pypi/tig3r/MAL-0000-tig3r.json
@@ -1,0 +1,44 @@
+{
+  "modified": "2025-02-25T15:52:00Z",
+  "published": "2025-02-25T15:52:00Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in tig3r (PyPI)",
+  "details": "This package is a web scraping tool to perform activities such as logging into Hotmail and checking the availability of emails or user IDs on platforms like TikTok, Instagram, and Telegram. However, these actions could potentially violate the terms of service of the respective providers or be flagged as suspicious activity. Additionally, the tool employs techniques such as randomizing user-agent strings and request data in an attempt to avoid detection.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "tig3r",
+        "purl": "pkg:pypi/tig3r"
+      },
+      "versions": [
+        "0.3",
+        "0.1"
+      ]
+    }
+  ],
+  "credits": [
+    {
+      "name": "Oracle using Macaron",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/oracle/macaron"
+      ]
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "import_time": "2025-02-25T15:52:00Z",
+        "modified_time": "2025-02-25T15:52:00Z",
+        "sha256": "b2de1543b72bec6f34964bcafdfe13a516ce342d8753885b76480a3caa600525",
+        "source": "Oracle using Macaron",
+        "versions": [
+          "0.3",
+          "0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/pypi/tiger-krd/MAL-0000-tiger-krd.json
+++ b/osv/malicious/pypi/tiger-krd/MAL-0000-tiger-krd.json
@@ -1,0 +1,42 @@
+{
+  "modified": "2025-03-24T10:27:00Z",
+  "published": "2025-03-24T10:27:00Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in tiger-krd (PyPI)",
+  "details": "This package is a web scraping tool to perform activities such as logging into Hotmail and checking the availability of emails or user IDs on platforms like TikTok, Instagram, and Telegram. However, these actions could potentially violate the terms of service of the respective providers or be flagged as suspicious activity. Additionally, the tool employs techniques such as randomizing user-agent strings and request data in an attempt to avoid detection.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "tiger-krd",
+        "purl": "pkg:pypi/tiger-krd"
+      },
+      "versions": [
+        "0.5"
+      ]
+    }
+  ],
+  "credits": [
+    {
+      "name": "Oracle using Macaron",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/oracle/macaron"
+      ]
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "import_time": "2025-03-24T10:27:00Z",
+        "modified_time": "2025-03-24T10:27:00Z",
+        "sha256": "93dd0e75a31453684e54882708351e38c1d300a8ce4d4dd2add1a793a671d78f",
+        "source": "Oracle using Macaron",
+        "versions": [
+          "0.5"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds two PyPI packages, likely created by the same threat actor, that have already been removed by the PyPI security team. These packages are designed for web scraping activities, including logging into Hotmail and checking the availability of emails or user IDs on platforms like TikTok, Instagram, and Telegram. The tool also employs techniques such as randomizing user-agent strings and request data to evade detection.