### PR TITLE
Validate source IDs conform to `[a-z0-9-]+` and fix oracle reports.

### DIFF
--- a/internal/report/origin_test.go
+++ b/internal/report/origin_test.go
@@ -1,0 +1,71 @@
+package report_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/ossf/malicious-packages/internal/report"
+)
+
+func TestOriginRefUnmarshalJSON(t *testing.T) {
+	in := `{
+		"source": "this-is-a-test-source-2",
+		"sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	}`
+	want := report.OriginRef{
+		Source: "this-is-a-test-source-2",
+		SHASum: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	}
+
+	var got report.OriginRef
+	err := got.UnmarshalJSON([]byte(in))
+	if err != nil {
+		t.Fatalf("Unmarshal() = %v; want nil", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Unmarhsal() return unexpected result = %v, want %v", got, want)
+	}
+}
+
+func TestOriginRefUnmarshalJSON_Error(t *testing.T) {
+	var got report.OriginRef
+	err := got.UnmarshalJSON([]byte("{"))
+
+	if err == nil {
+		t.Fatal("Unmarshal() = nil; want an error")
+	}
+}
+
+func TestOriginRefUnmarshalJSON_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "source is empty",
+			input: `{"source": "", "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+		},
+		{
+			name:  "source is invalid 1",
+			input: `{"source": "CAPITALS", "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+		},
+		{
+			name:  "source is invalid 2",
+			input: `{"source": "spaces in source", "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}`,
+		},
+		{
+			name:  "sha256 is empty",
+			input: `{"source": "valid-source", "sha256": ""}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var i report.OriginRef
+			if err := i.UnmarshalJSON([]byte(test.input)); !errors.Is(err, report.ErrUnexpectedOSV) {
+				t.Fatalf("Unmarshal() = %v; want = %v", err, report.ErrUnexpectedOSV)
+			}
+		})
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -93,6 +93,11 @@ func (r *Report) UnmarshalJSON(b []byte) error {
 	r.Ecosystem = string(r.raw.Affected[0].Package.Ecosystem)
 	r.Name = r.raw.Affected[0].Package.Name
 
+	// Ensure the details can be parsed.
+	if _, _, err := r.ParseDetails(); err != nil {
+		return fmt.Errorf("%w: invalid details: %w", ErrInvalidDetails, err)
+	}
+
 	return nil
 }
 

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -47,7 +47,7 @@ type Source struct {
 	filters reportfilter.Filters
 }
 
-func validateID(id string) error {
+func ValidateID(id string) error {
 	if id == "" {
 		return fmt.Errorf("%w: id must be set", ErrInvalidID)
 	}
@@ -76,7 +76,7 @@ func (s *Source) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(raw); err != nil {
 		return err
 	}
-	if err := validateID(raw.ID); err != nil {
+	if err := ValidateID(raw.ID); err != nil {
 		return err
 	}
 	fs, err := generateFilterSet(raw.Filters)

--- a/osv/malicious/pypi/blackspammerbd-bot/MAL-2025-2587.json
+++ b/osv/malicious/pypi/blackspammerbd-bot/MAL-2025-2587.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2587",
   "summary": "Malicious code in blackspammerbd-bot (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (6fd0fbf90d161b67f6df5c7e057b6ac660066232b4565e893e9e72bc43c86a1b)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (6fd0fbf90d161b67f6df5c7e057b6ac660066232b4565e893e9e72bc43c86a1b)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
   "affected": [
     {
       "package": {
@@ -30,10 +30,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "6fd0fbf90d161b67f6df5c7e057b6ac660066232b4565e893e9e72bc43c86a1b",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "6fd0fbf90d161b67f6df5c7e057b6ac660066232b4565e893e9e72bc43c86a1b",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0",
           "0.1"

--- a/osv/malicious/pypi/blackspammerbd-bsb/MAL-2025-2588.json
+++ b/osv/malicious/pypi/blackspammerbd-bsb/MAL-2025-2588.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2588",
   "summary": "Malicious code in blackspammerbd-bsb (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (95b4b100eae0bd8d8b1d4a439c713c11286796c1c07beaa4cc0749305ead3307)\nThis package performs data exfiltration and remote control of the system by generating connection codes, file uploads and downloads, and obfuscation. These actions could allow unauthorized access to sensitive information or remote manipulation of the system.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (95b4b100eae0bd8d8b1d4a439c713c11286796c1c07beaa4cc0749305ead3307)\nThis package performs data exfiltration and remote control of the system by generating connection codes, file uploads and downloads, and obfuscation. These actions could allow unauthorized access to sensitive information or remote manipulation of the system.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "95b4b100eae0bd8d8b1d4a439c713c11286796c1c07beaa4cc0749305ead3307",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "95b4b100eae0bd8d8b1d4a439c713c11286796c1c07beaa4cc0749305ead3307",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.1"
         ]

--- a/osv/malicious/pypi/blackspammerbd-one/MAL-2025-2589.json
+++ b/osv/malicious/pypi/blackspammerbd-one/MAL-2025-2589.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2589",
   "summary": "Malicious code in blackspammerbd-one (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (3a7030f8a8cf814fe46e26049ad685cd2bae16adadb8115cd5f42a87ed87c941)\nThis package performs data exfiltration and remote control of the system by generating connection codes, file uploads and downloads, and obfuscation. These actions could allow unauthorized access to sensitive information or remote manipulation of the system.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (3a7030f8a8cf814fe46e26049ad685cd2bae16adadb8115cd5f42a87ed87c941)\nThis package performs data exfiltration and remote control of the system by generating connection codes, file uploads and downloads, and obfuscation. These actions could allow unauthorized access to sensitive information or remote manipulation of the system.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "3a7030f8a8cf814fe46e26049ad685cd2bae16adadb8115cd5f42a87ed87c941",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "3a7030f8a8cf814fe46e26049ad685cd2bae16adadb8115cd5f42a87ed87c941",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/blackspammerbd-remot/MAL-2025-2590.json
+++ b/osv/malicious/pypi/blackspammerbd-remot/MAL-2025-2590.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2590",
   "summary": "Malicious code in blackspammerbd-remot (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (b3620d6bbda8c8e6a637f39997f1d22114756ec09e8e458eaab7287ea64ff7c3)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (b3620d6bbda8c8e6a637f39997f1d22114756ec09e8e458eaab7287ea64ff7c3)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "b3620d6bbda8c8e6a637f39997f1d22114756ec09e8e458eaab7287ea64ff7c3",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "b3620d6bbda8c8e6a637f39997f1d22114756ec09e8e458eaab7287ea64ff7c3",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/blackspammerbd-remot1/MAL-2025-2591.json
+++ b/osv/malicious/pypi/blackspammerbd-remot1/MAL-2025-2591.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2591",
   "summary": "Malicious code in blackspammerbd-remot1 (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (3618dd14b1eb36d5025d6a47cf69fbe08f06fa02c9de8338f7ca67ce5ef38fd9)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (3618dd14b1eb36d5025d6a47cf69fbe08f06fa02c9de8338f7ca67ce5ef38fd9)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "3618dd14b1eb36d5025d6a47cf69fbe08f06fa02c9de8338f7ca67ce5ef38fd9",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "3618dd14b1eb36d5025d6a47cf69fbe08f06fa02c9de8338f7ca67ce5ef38fd9",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/blackspammerbd-tg/MAL-2025-2592.json
+++ b/osv/malicious/pypi/blackspammerbd-tg/MAL-2025-2592.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2592",
   "summary": "Malicious code in blackspammerbd-tg (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (899ac6c3d1b62da3553aab693790598d0e87f6530b57d335deaee2545a39eb9c)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (899ac6c3d1b62da3553aab693790598d0e87f6530b57d335deaee2545a39eb9c)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "899ac6c3d1b62da3553aab693790598d0e87f6530b57d335deaee2545a39eb9c",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "899ac6c3d1b62da3553aab693790598d0e87f6530b57d335deaee2545a39eb9c",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/blackspammerbd-tool/MAL-2025-2593.json
+++ b/osv/malicious/pypi/blackspammerbd-tool/MAL-2025-2593.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2593",
   "summary": "Malicious code in blackspammerbd-tool (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (49490144c72d79e7bb37921a87c52011d6ce935fd7d031e2a4d3e4835e98a399)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (49490144c72d79e7bb37921a87c52011d6ce935fd7d031e2a4d3e4835e98a399)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "49490144c72d79e7bb37921a87c52011d6ce935fd7d031e2a4d3e4835e98a399",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "49490144c72d79e7bb37921a87c52011d6ce935fd7d031e2a4d3e4835e98a399",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/blackspammerbd-tooll/MAL-2025-2594.json
+++ b/osv/malicious/pypi/blackspammerbd-tooll/MAL-2025-2594.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2594",
   "summary": "Malicious code in blackspammerbd-tooll (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (d5e8e091db7011e3f7cef75872065e84b3ac54c31c4811271f7ac816301676f6)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (d5e8e091db7011e3f7cef75872065e84b3ac54c31c4811271f7ac816301676f6)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, data theft, or for distributing more malware.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "d5e8e091db7011e3f7cef75872065e84b3ac54c31c4811271f7ac816301676f6",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "d5e8e091db7011e3f7cef75872065e84b3ac54c31c4811271f7ac816301676f6",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/blackspammerbd-tools/MAL-2025-2595.json
+++ b/osv/malicious/pypi/blackspammerbd-tools/MAL-2025-2595.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2595",
   "summary": "Malicious code in blackspammerbd-tools (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (032eea352b83029c69620b0a45a9297f18ccf6dcf76418258d428e85ca8dc304)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, and data theft.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (032eea352b83029c69620b0a45a9297f18ccf6dcf76418258d428e85ca8dc304)\nThis package is designed for remote control and data exfiltration, and could be used for malicious purposes such as spying, unauthorized access, and data theft.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "032eea352b83029c69620b0a45a9297f18ccf6dcf76418258d428e85ca8dc304",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "032eea352b83029c69620b0a45a9297f18ccf6dcf76418258d428e85ca8dc304",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/blackspammerbd-v1/MAL-2025-2596.json
+++ b/osv/malicious/pypi/blackspammerbd-v1/MAL-2025-2596.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2596",
   "summary": "Malicious code in blackspammerbd-v1 (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (d696247c09031d2d4a82b6ec26822f3282f859aeaed36b9ef8a1c42c3f255c19)\nThe package performs data exfiltration and remote control of the system by generating connection codes, enabling file uploads and downloads, and obfuscation. These actions could allow unauthorized access to sensitive information or remote manipulation of the system.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (d696247c09031d2d4a82b6ec26822f3282f859aeaed36b9ef8a1c42c3f255c19)\nThe package performs data exfiltration and remote control of the system by generating connection codes, enabling file uploads and downloads, and obfuscation. These actions could allow unauthorized access to sensitive information or remote manipulation of the system.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "d696247c09031d2d4a82b6ec26822f3282f859aeaed36b9ef8a1c42c3f255c19",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "d696247c09031d2d4a82b6ec26822f3282f859aeaed36b9ef8a1c42c3f255c19",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.1"
         ]

--- a/osv/malicious/pypi/blackspammerbd/MAL-2025-2586.json
+++ b/osv/malicious/pypi/blackspammerbd/MAL-2025-2586.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2586",
   "summary": "Malicious code in blackspammerbd (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (610e92bd25b3f4e4206c9e4e0c321b5120bc85b6a01b289d192f78c53bff9ada)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (610e92bd25b3f4e4206c9e4e0c321b5120bc85b6a01b289d192f78c53bff9ada)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
   "affected": [
     {
       "package": {
@@ -30,10 +30,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "610e92bd25b3f4e4206c9e4e0c321b5120bc85b6a01b289d192f78c53bff9ada",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "610e92bd25b3f4e4206c9e4e0c321b5120bc85b6a01b289d192f78c53bff9ada",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0",
           "0.1"

--- a/osv/malicious/pypi/blackspammerbd1/MAL-2025-2597.json
+++ b/osv/malicious/pypi/blackspammerbd1/MAL-2025-2597.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2597",
   "summary": "Malicious code in blackspammerbd1 (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (b15da26ba7f4131e44fe665d836a9cd11bec3dc1701c7c35005e468a294cd4a0)\nThis package appears to function as a remote access tool, potentially enabling unauthorized access and facilitating data exfiltration. It seems to be part of a broader set of packages published from the same account, which raises concerns about a coordinated effort.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (b15da26ba7f4131e44fe665d836a9cd11bec3dc1701c7c35005e468a294cd4a0)\nThis package appears to function as a remote access tool, potentially enabling unauthorized access and facilitating data exfiltration. It seems to be part of a broader set of packages published from the same account, which raises concerns about a coordinated effort.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "b15da26ba7f4131e44fe665d836a9cd11bec3dc1701c7c35005e468a294cd4a0",
         "import_time": "2025-03-18T17:04:00Z",
         "modified_time": "2025-03-18T17:04:00Z",
-        "sha256": "b15da26ba7f4131e44fe665d836a9cd11bec3dc1701c7c35005e468a294cd4a0",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0"
         ]

--- a/osv/malicious/pypi/bsb-backup/MAL-2025-2621.json
+++ b/osv/malicious/pypi/bsb-backup/MAL-2025-2621.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2621",
   "summary": "Malicious code in bsb-backup (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (7c8850cc513318b8ede38268eed0fee01ba44c81087cd289294b63bada9f394c)\nThis package decodes and executes a script during installation to set up a Telegram bot for device event monitoring. However, the code is obfuscated, making it difficult to comprehend and obscuring its true intent.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (7c8850cc513318b8ede38268eed0fee01ba44c81087cd289294b63bada9f394c)\nThis package decodes and executes a script during installation to set up a Telegram bot for device event monitoring. However, the code is obfuscated, making it difficult to comprehend and obscuring its true intent.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "7c8850cc513318b8ede38268eed0fee01ba44c81087cd289294b63bada9f394c",
         "import_time": "2025-03-24T10:27:00Z",
         "modified_time": "2025-03-24T10:27:00Z",
-        "sha256": "7c8850cc513318b8ede38268eed0fee01ba44c81087cd289294b63bada9f394c",
-        "source": "Oracle using Macaron",
         "versions": [
           "2.0"
         ]

--- a/osv/malicious/pypi/bsb-connector/MAL-2025-2598.json
+++ b/osv/malicious/pypi/bsb-connector/MAL-2025-2598.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2598",
   "summary": "Malicious code in bsb-connector (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (ed806140937f50b1f0283cc8d7f9feb4a85562c25574e2dd35cdb6548901e0a9)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (ed806140937f50b1f0283cc8d7f9feb4a85562c25574e2dd35cdb6548901e0a9)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "ed806140937f50b1f0283cc8d7f9feb4a85562c25574e2dd35cdb6548901e0a9",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "ed806140937f50b1f0283cc8d7f9feb4a85562c25574e2dd35cdb6548901e0a9",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/bsb-family-bot/MAL-2025-2599.json
+++ b/osv/malicious/pypi/bsb-family-bot/MAL-2025-2599.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2599",
   "summary": "Malicious code in bsb-family-bot (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (73381c6a90c69556e5d81fd8b66b24eb30907c18f1b24a8a1de3635d533d3284)\nThis package decodes and executes a script during installation to set up a Telegram bot for device event monitoring. However, the code is obfuscated, making it difficult to comprehend and obscuring its true intent.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (73381c6a90c69556e5d81fd8b66b24eb30907c18f1b24a8a1de3635d533d3284)\nThis package decodes and executes a script during installation to set up a Telegram bot for device event monitoring. However, the code is obfuscated, making it difficult to comprehend and obscuring its true intent.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "73381c6a90c69556e5d81fd8b66b24eb30907c18f1b24a8a1de3635d533d3284",
         "import_time": "2025-03-18T17:03:00Z",
         "modified_time": "2025-03-18T17:03:00Z",
-        "sha256": "73381c6a90c69556e5d81fd8b66b24eb30907c18f1b24a8a1de3635d533d3284",
-        "source": "Oracle using Macaron",
         "versions": [
           "0.1.0"
         ]

--- a/osv/malicious/pypi/bsb-family-pack/MAL-2025-2600.json
+++ b/osv/malicious/pypi/bsb-family-pack/MAL-2025-2600.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2600",
   "summary": "Malicious code in bsb-family-pack (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (9ce94b3baee18c22e6c4de9808764de9496aa7a055a74f58eb972741ac433181)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (9ce94b3baee18c22e6c4de9808764de9496aa7a055a74f58eb972741ac433181)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "9ce94b3baee18c22e6c4de9808764de9496aa7a055a74f58eb972741ac433181",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "9ce94b3baee18c22e6c4de9808764de9496aa7a055a74f58eb972741ac433181",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/bsb-family-pack2/MAL-2025-2601.json
+++ b/osv/malicious/pypi/bsb-family-pack2/MAL-2025-2601.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2601",
   "summary": "Malicious code in bsb-family-pack2 (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (3c8e5ce70508c90e2093517061f924980b3f870682878633d12afdf9903b6ecf)\nThis package is designed to exfiltrate sensitive user data, including SMS messages, contacts, call logs, and files, to a remote server via Telegram. Such behavior suggests it could be used for surveillance or other malicious activities.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (3c8e5ce70508c90e2093517061f924980b3f870682878633d12afdf9903b6ecf)\nThis package is designed to exfiltrate sensitive user data, including SMS messages, contacts, call logs, and files, to a remote server via Telegram. Such behavior suggests it could be used for surveillance or other malicious activities.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "3c8e5ce70508c90e2093517061f924980b3f870682878633d12afdf9903b6ecf",
         "import_time": "2025-03-18T17:05:00Z",
         "modified_time": "2025-03-18T17:05:00Z",
-        "sha256": "3c8e5ce70508c90e2093517061f924980b3f870682878633d12afdf9903b6ecf",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/connector-bsb/MAL-2025-2602.json
+++ b/osv/malicious/pypi/connector-bsb/MAL-2025-2602.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2602",
   "summary": "Malicious code in connector-bsb (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (eed0770278358269212ff3971e9c4ee9d5410676ea27a4feb6ae52fa8cb5484b)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (eed0770278358269212ff3971e9c4ee9d5410676ea27a4feb6ae52fa8cb5484b)\nThis package seems to be part of a larger malicious toolkit designed for unauthorized access to systems, data theft, and potentially acting as a placeholder for making calls across other malicious packages.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "eed0770278358269212ff3971e9c4ee9d5410676ea27a4feb6ae52fa8cb5484b",
         "import_time": "2025-03-19T14:42:00Z",
         "modified_time": "2025-03-19T14:42:00Z",
-        "sha256": "eed0770278358269212ff3971e9c4ee9d5410676ea27a4feb6ae52fa8cb5484b",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]

--- a/osv/malicious/pypi/mstplotlib/MAL-2025-2345.json
+++ b/osv/malicious/pypi/mstplotlib/MAL-2025-2345.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2345",
   "summary": "Malicious code in mstplotlib (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (48409bd7f3f22c084f0f0269402f93d8327e3d8d89edf03641e8093e0b22938c)\nThis package is a typosquat of the matplotlib package and executes harmful code during installation. It appears to inject code into Python files (e.g., site.py) on the system.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (48409bd7f3f22c084f0f0269402f93d8327e3d8d89edf03641e8093e0b22938c)\nThis package is a typosquat of the matplotlib package and executes harmful code during installation. It appears to inject code into Python files (e.g., site.py) on the system.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "48409bd7f3f22c084f0f0269402f93d8327e3d8d89edf03641e8093e0b22938c",
         "import_time": "2025-02-20T06:37:06Z",
         "modified_time": "2025-02-20T06:37:06Z",
-        "sha256": "48409bd7f3f22c084f0f0269402f93d8327e3d8d89edf03641e8093e0b22938c",
-        "source": "Oracle using Macaron",
         "versions": [
           "3.10.2"
         ]

--- a/osv/malicious/pypi/team-bsb-bot/MAL-2025-2622.json
+++ b/osv/malicious/pypi/team-bsb-bot/MAL-2025-2622.json
@@ -4,7 +4,7 @@
   "schema_version": "1.5.0",
   "id": "MAL-2025-2622",
   "summary": "Malicious code in team-bsb-bot (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: Oracle using Macaron (da5627aaacdf2bd8ab0ce2e469ea8635108e857776ed8766ee9df47c4b66aaa8)\nThis package appears to be part of a larger ecosystem acting as a placeholder for orchestrating interactions with other bsb malicious packages.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: oracle-using-macaron (da5627aaacdf2bd8ab0ce2e469ea8635108e857776ed8766ee9df47c4b66aaa8)\nThis package appears to be part of a larger ecosystem acting as a placeholder for orchestrating interactions with other bsb malicious packages.\n",
   "affected": [
     {
       "package": {
@@ -29,10 +29,10 @@
   "database_specific": {
     "malicious-packages-origins": [
       {
+        "source": "oracle-using-macaron",
+        "sha256": "da5627aaacdf2bd8ab0ce2e469ea8635108e857776ed8766ee9df47c4b66aaa8",
         "import_time": "2025-03-24T10:27:00Z",
         "modified_time": "2025-03-24T10:27:00Z",
-        "sha256": "da5627aaacdf2bd8ab0ce2e469ea8635108e857776ed8766ee9df47c4b66aaa8",
-        "source": "Oracle using Macaron",
         "versions": [
           "1.0.0"
         ]


### PR DESCRIPTION
Ensure the sourceIDs that are encountered are valid when reports are parsed.

This also includes ensuring that the details section can be parsed as well.

"Oracle using Macaron" records now use the source "oracle-using-macaron" to conform.