### PR TITLE
Add report for the dscss PyPI package

### DIFF
--- a/osv/malicious/pypi/dscss/MAL-0000-dscss.json
+++ b/osv/malicious/pypi/dscss/MAL-0000-dscss.json
@@ -1,0 +1,44 @@
+{
+  "modified": "2024-12-29T05:03:00.000Z",
+  "published": "2024-12-29T05:03:00.000Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in dscss (PyPI)",
+  "details": "This package contains a highly obfuscated code and executes the code in a long hexadecimal string.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "dscss",
+        "purl": "pkg:pypi/dscss"
+      },
+      "versions": [
+        "1.0.1",
+        "1.0.0"
+      ]
+    }
+  ],
+  "credits": [
+    {
+      "name": "Oracle using Macaron",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/oracle/macaron"
+      ]
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "oracle-using-macaron",
+        "sha256": "fb41535db040ebc6147f3cfe1bfc3f5638402e85fc889d78d6101814d6f4bc10",
+        "import_time": "2024-12-29T05:03:00.000Z",
+        "modified_time": "2024-12-29T05:03:00.000Z",
+        "versions": [
+          "1.0.1",
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds a report for the malicious Python package `dscss` found on PyPI.