### PR TITLE
Remove the overly broad match from GHSA to limit scanner noise.

### DIFF
--- a/osv/malicious/npm/primereact-sass-theme/MAL-2025-4574.json
+++ b/osv/malicious/npm/primereact-sass-theme/MAL-2025-4574.json
@@ -22,14 +22,6 @@
               "introduced": "100.0.0"
             }
           ]
-        },
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
         }
       ],
       "database_specific": {


### PR DESCRIPTION
The GitHub repo github.com/primefaces/primereact-sass-theme uses a package.json file for this name squatting attack and has a version 10.8.5.

The overly broad version range from GitHub that covers every version means that this repo is matched and if someone has the repo checked out it will be potentially considered malicious by a scanning tool.

This change leaves the original version range from @awsactran.