### PR TITLE
Report malicious npm eslint-plugin-pannel-ops package

### DIFF
--- a/osv/malicious/npm/eslint-plugin-panel-ops/MAL-0000-eslint-plugin-panel-ops.json
+++ b/osv/malicious/npm/eslint-plugin-panel-ops/MAL-0000-eslint-plugin-panel-ops.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-06-16T10:44:09Z",
+  "published": "2025-06-16T10:44:09Z",
+  "schema_version": "1.6.8",
+  "summary": "Malicious code in eslint-plugin-panel-ops package (npm)",
+  "details": "Malware: Executes code on install, exfiltrates data via DNS to a suspicious domain. Contains a preinstall script and phone-home behavior.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eslint-plugin-panel-ops"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0.0.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://platform.safedep.io/community/malysis/01JXW1MVVQZ7XG947RD363HA1A"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The package is a malware because it contains a preinstall script that executes arbitrary code (node index.js). The index.js file collects sensitive information (IP, MAC, hostname, username, CWD) and exfiltrates it via DNS resolution to a suspicious domain (d17u6rtjp2jt2l9c64u0mhagodssdwzxf.oast.me). This behavior is highly indicative of malicious intent. The YARA rules nodejs_phone_home and npm_preinstall_command confirm this assessment.