### PR TITLE
Bump the osv-schema hash used for ingesting GHSA reports.

### DIFF
--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -27,20 +27,20 @@ jobs:
       with:
         token: ${{ secrets.GH_TOKEN }}
         repository: ossf/osv-schema
-        ref: ed713ef6511fa4113c89e25ea5e3da5291c6f05d
+        ref: 180f03cc6901693aa1cb3c672534c7b3f4e99d7b
         path: osv-schema
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version-file: 'go.mod'
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: "3.11"
+        python-version: "3.13"
         cache: pipenv
         cache-dependency-path: osv-schema/tools/ghsa/Pipfile.lock
 
     - name: Install pipenv
       run: |
-        pip install pipenv==2023.7.11
+        pip install pipenv==2025.0.3
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This should restore the GHSA ingestion, which is currently broken.