### PR TITLE
Add support for changing how counts are grouped.

### DIFF
--- a/cmd/stats/collector/collector.go
+++ b/cmd/stats/collector/collector.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Malicious Packages Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Collector is used to help collect counts across zero or more dimensions.
+type Collector struct {
+	name   string
+	dims   []string
+	keys   []map[string]struct{}
+	counts map[string]int
+}
+
+// New creates an instance of Collector for counting the named metric across
+// the dimensions supplied in dims.
+func New(name string, dims ...string) *Collector {
+	c := &Collector{
+		name:   name,
+		dims:   dims,
+		counts: make(map[string]int),
+	}
+	for range dims {
+		c.keys = append(c.keys, make(map[string]struct{}))
+	}
+	return c
+}
+
+// Inc increments the count with each of the keys corresponding to the
+// defined dimensions.
+func (c *Collector) Inc(keys ...string) {
+	for i, key := range keys {
+		c.keys[i][key] = struct{}{}
+	}
+	c.counts[strings.Join(keys, ",")]++
+}
+
+func (c *Collector) count(keys []string) int {
+	return c.counts[strings.Join(keys, ",")]
+}
+
+func (c *Collector) enumKeys() [][]string {
+	var keyParts [][]string
+	for i := range c.dims {
+		dimKeys := slices.Sorted(maps.Keys(c.keys[i]))
+		if len(keyParts) == 0 {
+			for _, key := range dimKeys {
+				keyParts = append(keyParts, []string{key})
+			}
+			continue
+		}
+		newKeyParts := [][]string{}
+		for _, parts := range keyParts {
+			for _, key := range dimKeys {
+				newKeyParts = append(newKeyParts, append(parts, key))
+			}
+		}
+		keyParts = newKeyParts
+	}
+	return keyParts
+}
+
+func (c *Collector) ForJSON() any {
+	if len(c.counts) == 0 {
+		return nil
+	}
+
+	allKeys := c.enumKeys()
+	if len(allKeys) == 0 {
+		return c.count([]string{})
+	}
+
+	res := make(map[string]any)
+	for _, keys := range allKeys {
+		v := c.count(keys)
+		if v == 0 {
+			continue
+		}
+
+		// Construct the map of maps.
+		innerRes := res
+		for _, key := range keys[:len(keys)-1] {
+			if _, ok := innerRes[key]; !ok {
+				innerRes[key] = make(map[string]any)
+			}
+			innerRes = innerRes[key].(map[string]any)
+		}
+
+		// Use the final key to store the value.
+		innerRes[keys[len(keys)-1]] = v
+	}
+	return res
+}
+
+func (c *Collector) ForCSV() [][]string {
+	res := [][]string{append(c.dims, c.name)}
+
+	if len(c.counts) == 0 {
+		// No records, so abort.
+		return res
+	}
+
+	allKeys := c.enumKeys()
+	if len(allKeys) == 0 {
+		// The keys are all empty, but we have a value. This means that there is
+		// is only a single value.
+		return append(res, []string{strconv.Itoa(c.count([]string{}))})
+	}
+
+	for _, keys := range allKeys {
+		v := c.count(keys)
+		if v == 0 {
+			continue
+		}
+		row := make([]string, len(c.dims))
+		copy(row, keys)
+		row = append(row, strconv.Itoa(v))
+		res = append(res, row)
+	}
+	return res
+}

--- a/cmd/stats/collector/collector_test.go
+++ b/cmd/stats/collector/collector_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Malicious Packages Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ossf/malicious-packages/cmd/stats/collector"
+)
+
+func TestNew(t *testing.T) {
+	c := collector.New("test collector", "col1", "col2")
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+	// Basic check for initialization. More detailed checks are in other tests.
+	csv := c.ForCSV()
+	if !reflect.DeepEqual(csv[0], []string{"col1", "col2", "test collector"}) {
+		t.Errorf("ForCSV() header = %v, want %v", csv[0], []string{"col1", "col2", "test collector"})
+	}
+}
+
+func TestInc(t *testing.T) {
+	c := collector.New("test", "ecosystem", "date")
+	c.Inc("npm", "2025-01-01")
+	c.Inc("npm", "2025-01-01")
+	c.Inc("pypi", "2025-01-01")
+	c.Inc("npm", "2025-02-01")
+
+	got := c.ForCSV()
+	want := [][]string{
+		{"ecosystem", "date", "test"},
+		{"npm", "2025-01-01", "2"},
+		{"npm", "2025-02-01", "1"},
+		{"pypi", "2025-01-01", "1"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ForCSV() = %v, want %v", got, want)
+	}
+}
+
+func TestInc_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	c := collector.New("test", "one_col")
+	// Should panic because it expects 1 key but gets 2.
+	c.Inc("key1", "key2")
+}
+
+func TestForCSV(t *testing.T) {
+	c := collector.New("report counts", "ecosystem", "year")
+	c.Inc("npm", "2024")
+	c.Inc("pypi", "2025")
+	c.Inc("npm", "2024")
+	c.Inc("go", "2024")
+	c.Inc("pypi", "2024")
+
+	got := c.ForCSV()
+	want := [][]string{
+		{"ecosystem", "year", "report counts"},
+		{"go", "2024", "1"},
+		{"npm", "2024", "2"},
+		{"pypi", "2024", "1"},
+		{"pypi", "2025", "1"},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ForCSV() got = %v, want %v", got, want)
+	}
+}
+
+func TestForJSON(t *testing.T) {
+	c := collector.New("counts", "ecosystem", "date")
+	c.Inc("npm", "2025-01")
+	c.Inc("npm", "2025-01")
+	c.Inc("pypi", "2025-01")
+	c.Inc("npm", "2025-02")
+	c.Inc("go", "2025-03")
+
+	got := c.ForJSON()
+	want := map[string]any{
+		"go": map[string]any{
+			"2025-03": 1,
+		},
+		"npm": map[string]any{
+			"2025-01": 2,
+			"2025-02": 1,
+		},
+		"pypi": map[string]any{
+			"2025-01": 1,
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ForJSON() got = %v, want %v", got, want)
+	}
+}
+
+func TestCollector_NoColumns(t *testing.T) {
+	c := collector.New("total")
+	c.Inc()
+	c.Inc()
+	c.Inc()
+
+	gotCSV := c.ForCSV()
+	wantCSV := [][]string{
+		{"total"},
+		{"3"},
+	}
+	if !reflect.DeepEqual(gotCSV, wantCSV) {
+		t.Errorf("ForCSV() = %v, want %v", gotCSV, wantCSV)
+	}
+
+	gotJSON := c.ForJSON()
+	wantJSON := 3
+	if gotJSON != wantJSON {
+		t.Errorf("ForJSON() = %v, want %v", gotJSON, wantJSON)
+	}
+}
+
+func TestCollector_Empty(t *testing.T) {
+	c := collector.New("empty", "col1")
+
+	gotCSV := c.ForCSV()
+	wantCSV := [][]string{
+		{"col1", "empty"},
+	}
+	if !reflect.DeepEqual(gotCSV, wantCSV) {
+		t.Errorf("ForCSV() = %v, want %v", gotCSV, wantCSV)
+	}
+
+	gotJSON := c.ForJSON()
+	if gotJSON != nil {
+		t.Errorf("ForJSON() = %v, want nil", gotJSON)
+	}
+}
+
+func TestForJSON_SingleColumn(t *testing.T) {
+	c := collector.New("counts", "ecosystem")
+	c.Inc("npm")
+	c.Inc("npm")
+	c.Inc("pypi")
+
+	got := c.ForJSON()
+	want := map[string]any{
+		"npm":  2,
+		"pypi": 1,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ForJSON() got = %v, want %v", got, want)
+	}
+}

--- a/cmd/stats/main.go
+++ b/cmd/stats/main.go
@@ -21,28 +21,55 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
-	"maps"
 	"os"
 	"path/filepath"
-	"slices"
-	"strconv"
 	"strings"
-	"time"
 
+	"github.com/ossf/malicious-packages/cmd/stats/collector"
 	"github.com/ossf/malicious-packages/internal/config"
 	"github.com/ossf/malicious-packages/internal/report"
 	"github.com/ossf/malicious-packages/internal/reportio"
 )
 
+var dateGroupMap = map[string]struct {
+	format string
+	suffix string
+}{
+	"month": {
+		format: "2006-01",
+		suffix: "-01",
+	},
+	"year": {
+		format: "2006",
+		suffix: "-01-01",
+	},
+}
+
 func main() {
 	csvFlag := flag.String("csv", "stats.csv", "the filepath to write the CSV file")
 	jsonFlag := flag.String("json", "", "the filepath to write the JSON file")
 	configFlag := flag.String("config", "", "the filepath to the YAML config file")
+	dateGroupFlag := flag.String("by-date", "month", "what granularity to group by date. Can be one of 'month', 'year', or empty to disable grouping")
+	ecoGroupFlag := flag.Bool("by-ecosystem", true, "whether to group by ecosystem. Enabled by default")
 	flag.Parse()
 
 	if *csvFlag == "" && *jsonFlag == "" {
 		log.Fatalf("-csv or -json flag is required")
 	}
+
+	cols := []string{}
+	if *ecoGroupFlag {
+		cols = append(cols, "ecosystem")
+	}
+
+	if *dateGroupFlag != "" {
+		if _, ok := dateGroupMap[*dateGroupFlag]; !ok {
+			log.Fatalf("-by-date must be either empty, 'month', or 'year'")
+		}
+		cols = append(cols, *dateGroupFlag)
+	}
+	dateGroup := dateGroupMap[*dateGroupFlag]
+	collector := collector.New("published reports", cols...)
 
 	if *configFlag == "" {
 		log.Fatalf("-config flag is required")
@@ -59,31 +86,35 @@ func main() {
 	}
 
 	log.Println("Processing OSV files...")
-	// ecosystem -> month -> count
-	stats := make(map[string]map[string]int)
-	if err := processRepo(c, stats); err != nil {
+	process := func(r *report.Report) {
+		keys := []string{}
+		if *ecoGroupFlag {
+			keys = append(keys, r.Ecosystem)
+		}
+		if *dateGroupFlag != "" {
+			keys = append(keys, r.Published().UTC().Format(dateGroup.format)+dateGroup.suffix)
+		}
+		collector.Inc(keys...)
+	}
+
+	if err := processRepo(c, process); err != nil {
 		log.Fatalf("Failed to process repo: %v", err)
 	}
 
 	if *csvFlag != "" {
 		log.Printf("Writing CSV to %s...", *csvFlag)
-		if err := writeCSV(*csvFlag, stats); err != nil {
+		if err := writeCSV(*csvFlag, collector.ForCSV()); err != nil {
 			log.Fatalf("Failed to write CSV: %v", err)
 		}
 	}
 	if *jsonFlag != "" {
 		log.Printf("Writing JSON to %s...", *jsonFlag)
-		if err := writeJSON(*jsonFlag, stats); err != nil {
+		if err := writeJSON(*jsonFlag, collector.ForJSON()); err != nil {
 			log.Fatalf("Failed to write JSON: %v", err)
 		}
 	}
 
 	log.Println("Done.")
-}
-
-func formatMonth(t time.Time) string {
-	date := t.UTC().Format("2006-01-02")
-	return date[:7] + "-01"
 }
 
 // hasID returns true if base starts with "{prefix}-", but does not start with
@@ -93,7 +124,7 @@ func hasID(prefix, base string) bool {
 	return strings.HasPrefix(base, fmt.Sprintf("%s-", prefix)) && !strings.HasPrefix(base, fmt.Sprintf("%s-0000-", prefix))
 }
 
-func processRepo(c *config.Config, stats map[string]map[string]int) error {
+func processRepo(c *config.Config, process func(*report.Report)) error {
 	err := filepath.WalkDir(c.MaliciousPath, fs.WalkDirFunc(func(path string, info fs.DirEntry, err error) error {
 		if os.IsNotExist(err) {
 			return filepath.SkipDir
@@ -110,30 +141,25 @@ func processRepo(c *config.Config, stats map[string]map[string]int) error {
 			// Skip any file that doesn't match our ID pattern.
 			return nil
 		}
-		return processReport(path, stats)
+		return processReport(path, process)
 	}))
 	return err
 }
 
-func processReport(path string, stats map[string]map[string]int) error {
+func processReport(path string, process func(*report.Report)) error {
 	log.Printf("Processing %s", path)
 
 	r, err := report.FromFile(path)
 	if err != nil {
 		return fmt.Errorf("failed loading report %s: %w", path, err)
 	}
-	ecosystem := r.Ecosystem
-	month := formatMonth(r.Published())
 
-	if _, ok := stats[ecosystem]; !ok {
-		stats[ecosystem] = make(map[string]int)
-	}
-	stats[ecosystem][month]++
+	process(r)
 
 	return nil
 }
 
-func writeJSON(path string, stats map[string]map[string]int) error {
+func writeJSON(path string, stats any) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
@@ -148,7 +174,7 @@ func writeJSON(path string, stats map[string]map[string]int) error {
 	return nil
 }
 
-func writeCSV(path string, stats map[string]map[string]int) error {
+func writeCSV(path string, stats [][]string) error {
 	f, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
@@ -158,25 +184,10 @@ func writeCSV(path string, stats map[string]map[string]int) error {
 	w := csv.NewWriter(f)
 	defer w.Flush()
 
-	if err := w.Write([]string{"ecosystem", "month", "published reports"}); err != nil {
-		return fmt.Errorf("failed to write header: %w", err)
-	}
-
-	ecosystems := slices.Sorted(maps.Keys(stats))
-	for _, eco := range ecosystems {
-		months := slices.Sorted(maps.Keys(stats[eco]))
-		for _, month := range months {
-			count := stats[eco][month]
-			row := []string{
-				eco,
-				month,
-				strconv.Itoa(count),
-			}
-			if err := w.Write(row); err != nil {
-				return fmt.Errorf("failed to write row: %w", err)
-			}
+	for _, row := range stats {
+		if err := w.Write(row); err != nil {
+			return fmt.Errorf("failed to write row: %w", err)
 		}
 	}
-
 	return nil
 }


### PR DESCRIPTION
This allows:
- grouping by ecosystem to be enabled/disabled.
- grouping by month, year or all time.

To support this a simple helper library called "collector" was added.

#910 