### PR TITLE
Add malicious package entries for compromised DuckDB packages (GHSA-w62p-hx95-gf2c)

### DIFF
--- a/osv/malicious/npm/@duckdb/duckdb-wasm/MAL-0000-duckdb-wasm-compromised.json
+++ b/osv/malicious/npm/@duckdb/duckdb-wasm/MAL-0000-duckdb-wasm-compromised.json
@@ -1,0 +1,56 @@
+{
+  "modified": "2025-01-15T10:30:00Z",
+  "published": "2025-01-15T10:30:00Z",
+  "schema_version": "1.5.0",
+  "details": "The DuckDB Node.js package @duckdb/duckdb-wasm version 1.29.2 was compromised with malware through a sophisticated phishing attack targeting the DuckDB maintainers. An attacker created a pixel-perfect copy of the npmjs.com website at npmjs.help domain and tricked a maintainer into logging in and resetting 2FA. The attacker then used stolen credentials to publish malicious versions of DuckDB packages.\n\nThe malicious code was designed to interfere with cryptocurrency transactions, potentially allowing the attacker to steal or manipulate crypto wallet addresses and transactions. This represents a supply chain attack where legitimate packages were compromised to distribute malware.\n\nThe attack was discovered within 4 hours and the affected versions were immediately deprecated and deleted from npm. The maintainers re-released safe versions (1.30.0) to ensure users get clean packages.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@duckdb/duckdb-wasm"
+      },
+      "versions": [
+        "1.29.2"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          },
+          {
+            "cweId": "CWE-345",
+            "description": "The software does not verify or incorrectly verifies the cryptographic signature of data.",
+            "name": "Insufficient Verification of Data Authenticity"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/duckdb/duckdb-node/security/advisories/GHSA-w62p-hx95-gf2c"
+    }
+  ],
+  "credits": [
+    {
+      "name": "DuckDB Team",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/duckdb/duckdb-node"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "npmjs.help"
+      ],
+      "urls": [
+        "https://npmjs.help"
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/@duckdb/node-api/MAL-0000-duckdb-node-api-compromised.json
+++ b/osv/malicious/npm/@duckdb/node-api/MAL-0000-duckdb-node-api-compromised.json
@@ -1,0 +1,56 @@
+{
+  "modified": "2025-01-15T10:30:00Z",
+  "published": "2025-01-15T10:30:00Z",
+  "schema_version": "1.5.0",
+  "details": "The DuckDB Node.js package @duckdb/node-api version 1.3.3 was compromised with malware through a sophisticated phishing attack targeting the DuckDB maintainers. An attacker created a pixel-perfect copy of the npmjs.com website at npmjs.help domain and tricked a maintainer into logging in and resetting 2FA. The attacker then used stolen credentials to publish malicious versions of DuckDB packages.\n\nThe malicious code was designed to interfere with cryptocurrency transactions, potentially allowing the attacker to steal or manipulate crypto wallet addresses and transactions. This represents a supply chain attack where legitimate packages were compromised to distribute malware.\n\nThe attack was discovered within 4 hours and the affected versions were immediately deprecated and deleted from npm. The maintainers re-released safe versions (1.3.4) to ensure users get clean packages.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@duckdb/node-api"
+      },
+      "versions": [
+        "1.3.3"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          },
+          {
+            "cweId": "CWE-345",
+            "description": "The software does not verify or incorrectly verifies the cryptographic signature of data.",
+            "name": "Insufficient Verification of Data Authenticity"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/duckdb/duckdb-node/security/advisories/GHSA-w62p-hx95-gf2c"
+    }
+  ],
+  "credits": [
+    {
+      "name": "DuckDB Team",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/duckdb/duckdb-node"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "npmjs.help"
+      ],
+      "urls": [
+        "https://npmjs.help"
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/@duckdb/node-bindings/MAL-0000-duckdb-node-bindings-compromised.json
+++ b/osv/malicious/npm/@duckdb/node-bindings/MAL-0000-duckdb-node-bindings-compromised.json
@@ -1,0 +1,56 @@
+{
+  "modified": "2025-01-15T10:30:00Z",
+  "published": "2025-01-15T10:30:00Z",
+  "schema_version": "1.5.0",
+  "details": "The DuckDB Node.js package @duckdb/node-bindings version 1.3.3 was compromised with malware through a sophisticated phishing attack targeting the DuckDB maintainers. An attacker created a pixel-perfect copy of the npmjs.com website at npmjs.help domain and tricked a maintainer into logging in and resetting 2FA. The attacker then used stolen credentials to publish malicious versions of DuckDB packages.\n\nThe malicious code was designed to interfere with cryptocurrency transactions, potentially allowing the attacker to steal or manipulate crypto wallet addresses and transactions. This represents a supply chain attack where legitimate packages were compromised to distribute malware.\n\nThe attack was discovered within 4 hours and the affected versions were immediately deprecated and deleted from npm. The maintainers re-released safe versions (1.3.4) to ensure users get clean packages.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@duckdb/node-bindings"
+      },
+      "versions": [
+        "1.3.3"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          },
+          {
+            "cweId": "CWE-345",
+            "description": "The software does not verify or incorrectly verifies the cryptographic signature of data.",
+            "name": "Insufficient Verification of Data Authenticity"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/duckdb/duckdb-node/security/advisories/GHSA-w62p-hx95-gf2c"
+    }
+  ],
+  "credits": [
+    {
+      "name": "DuckDB Team",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/duckdb/duckdb-node"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "npmjs.help"
+      ],
+      "urls": [
+        "https://npmjs.help"
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/duckdb/MAL-0000-duckdb-compromised.json
+++ b/osv/malicious/npm/duckdb/MAL-0000-duckdb-compromised.json
@@ -1,0 +1,56 @@
+{
+  "modified": "2025-01-15T10:30:00Z",
+  "published": "2025-01-15T10:30:00Z",
+  "schema_version": "1.5.0",
+  "details": "The DuckDB Node.js package duckdb version 1.3.3 was compromised with malware through a sophisticated phishing attack targeting the DuckDB maintainers. An attacker created a pixel-perfect copy of the npmjs.com website at npmjs.help domain and tricked a maintainer into logging in and resetting 2FA. The attacker then used stolen credentials to publish malicious versions of DuckDB packages.\n\nThe malicious code was designed to interfere with cryptocurrency transactions, potentially allowing the attacker to steal or manipulate crypto wallet addresses and transactions. This represents a supply chain attack where legitimate packages were compromised to distribute malware.\n\nThe attack was discovered within 4 hours and the affected versions were immediately deprecated and deleted from npm. The maintainers re-released safe versions (1.3.4) to ensure users get clean packages.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "duckdb"
+      },
+      "versions": [
+        "1.3.3"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          },
+          {
+            "cweId": "CWE-345",
+            "description": "The software does not verify or incorrectly verifies the cryptographic signature of data.",
+            "name": "Insufficient Verification of Data Authenticity"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/duckdb/duckdb-node/security/advisories/GHSA-w62p-hx95-gf2c"
+    }
+  ],
+  "credits": [
+    {
+      "name": "DuckDB Team",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/duckdb/duckdb-node"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "npmjs.help"
+      ],
+      "urls": [
+        "https://npmjs.help"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Similar to https://github.com/ossf/malicious-packages/pull/979

https://github.com/duckdb/duckdb-node/security/advisories/GHSA-w62p-hx95-gf2c

