### PR TITLE
Malicious ng2-file-upload

### DIFF
--- a/osv/malicious/npm/ng2-file-upload/MAL-0000-ng2-file-upload.json
+++ b/osv/malicious/npm/ng2-file-upload/MAL-0000-ng2-file-upload.json
@@ -1,0 +1,30 @@
+{
+	"schema_version": "1.5.0",
+	"summary": "Malicious code in ng2-file-upload (npm)",
+	"details": "The package ng2-file-upload was found have been identified as potentially malicious due to the inclusion of a minified postinstall script. It is considered suspicious because: The script appears to attempt to steal access tokens for npm, GitHub, AWS, GCP, etc. There is no changelog or new tags in the GitHub repository associated with these releases. The packages were uploaded by a service account: https://www.npmjs.com/~ngxbs",
+	"affected": [
+		{
+			"package": {
+				"ecosystem": "npm",
+				"name": "ng2-file-upload"
+			},
+			"versions": [
+              "7.0.2",
+			  "7.0.3",
+			  "8.0.1",
+			  "8.0.2",
+			  "8.0.3",
+			  "9.0.1"
+			]
+		}
+	],
+	"credits": [
+		{
+			"name": "Rohde & Schwarz",
+			"type": "FINDER",
+			"contact": [
+				"productsecurity@rohde-schwarz.com"
+			]
+		}
+	]
+}

--- a/osv/malicious/npm/ngx-bootstrap/MAL-0000-ngx-bootstrap.json
+++ b/osv/malicious/npm/ngx-bootstrap/MAL-0000-ngx-bootstrap.json
@@ -1,0 +1,31 @@
+{
+	"schema_version": "1.5.0",
+	"summary": "Malicious code in ngx-bootstrap (npm)",
+	"details": "The package ngx-bootstrap was found have been identified as potentially malicious due to the inclusion of a minified postinstall script. It is considered suspicious because: The script appears to attempt to steal access tokens for npm, GitHub, AWS, GCP, etc. There is no changelog or new tags in the GitHub repository associated with these releases. The packages were uploaded by a service account: https://www.npmjs.com/~ngxbs",
+	"affected": [
+		{
+			"package": {
+				"ecosystem": "npm",
+				"name": "ngx-bootstrap"
+			},
+			"versions": [
+			  "18.1.4",
+			  "19.0.3",
+			  "19.0.4",
+			  "20.0.3",
+			  "20.0.4",
+			  "20.0.5",
+			  "20.0.6"
+			]
+		}
+	],
+	"credits": [
+		{
+			"name": "Rohde & Schwarz",
+			"type": "FINDER",
+			"contact": [
+				"productsecurity@rohde-schwarz.com"
+			]
+		}
+	]
+}


### PR DESCRIPTION
The package ng2-file-upload have been identified as potentially malicious due to the inclusion of a minified postinstall script.

- It is considered suspicious because: The script appears to attempt to steal access tokens for npm, GitHub, AWS, GCP, etc.
- There is no changelog or new tags in the GitHub repository associated with these releases.
- The packages were uploaded by a service account: https://www.npmjs.com/~ngxbs