### PR TITLE
Try and debug issues with GHSA ingest by uploading OSV

### DIFF
--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -59,7 +59,7 @@ jobs:
         cd osv-schema/tools/ghsa
         mkdir OSV
         pipenv run python convert_ghsa.py -o OSV OUT/*.json
-
+    
     - name: Ingest OSV
       run: |
         go run ./cmd/ingest -config config/config.yaml -dir osv-schema/tools/ghsa/OSV -source ghsa-malware
@@ -73,3 +73,10 @@ jobs:
       run: git diff --cached --quiet || git commit -m 'Ingest OSV - GHSA Malware'
     - name: Push commit
       run: git push
+
+    - name: Save OSV for debugging
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: ghsa-osv
+        path: osv-schema/tools/ghsa/OSV/*.json
+        retention-days: 14

--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -59,7 +59,7 @@ jobs:
         cd osv-schema/tools/ghsa
         mkdir OSV
         pipenv run python convert_ghsa.py -o OSV OUT/*.json
-    
+
     - name: Ingest OSV
       run: |
         go run ./cmd/ingest -config config/config.yaml -dir osv-schema/tools/ghsa/OSV -source ghsa-malware


### PR DESCRIPTION
Attempt to diagnose the cause of #1002 by collecting the OSV reports used to generate the hashes.

This change stores the reports as artifacts on the workflow at the end.

Once this has run for a few days reports for the same GHSA can be downloaded and compared across days.