### PR TITLE
Update commit id for osv-schema repo to pull in new osv dep.

### DIFF
--- a/.github/workflows/ingest-ghsa.yml
+++ b/.github/workflows/ingest-ghsa.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         token: ${{ secrets.GH_TOKEN }}
         repository: ossf/osv-schema
-        ref: 180f03cc6901693aa1cb3c672534c7b3f4e99d7b
+        ref: aeaeeeeb3f6473c294fc1d18a32e9a5a794a5c47
         path: osv-schema
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install pipenv
       run: |
-        pip install pipenv==2025.0.3
+        pip install pipenv==2025.0.4
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This will ensure GHSA reports are consistent between runs by sorting the JSON keys when the report is written by "convert_ghsa.py"

Fixes #1002 