### PR TITLE
Add reports for PhantomRaven campaign.

### DIFF
--- a/osv/malicious/npm/@acme-types/acme-package/MAL-0000-google-open-source-security-d2f857f12a85ce5a.json
+++ b/osv/malicious/npm/@acme-types/acme-package/MAL-0000-google-open-source-security-d2f857f12a85ce5a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @acme-types/acme-package (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@acme-types/acme-package"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d2f857f12a85ce5ac1b726195f454c150a111e0ff809dbf9b2688c0177cb85c2",
+        "import_time": "2025-10-30T03:28:38.263555Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@aio-commerce-sdk/config-tsdown/MAL-0000-google-open-source-security-a9f76128cdeae7b7.json
+++ b/osv/malicious/npm/@aio-commerce-sdk/config-tsdown/MAL-0000-google-open-source-security-a9f76128cdeae7b7.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @aio-commerce-sdk/config-tsdown (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@aio-commerce-sdk/config-tsdown"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a9f76128cdeae7b70292a80af87a269fc1b085c76c13dc793dd18aeff1e6a902",
+        "import_time": "2025-10-30T03:28:38.304882Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@aio-commerce-sdk/config-typedoc/MAL-0000-google-open-source-security-936cc6ca59909408.json
+++ b/osv/malicious/npm/@aio-commerce-sdk/config-typedoc/MAL-0000-google-open-source-security-936cc6ca59909408.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @aio-commerce-sdk/config-typedoc (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@aio-commerce-sdk/config-typedoc"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "936cc6ca5990940819cac5433e251db97d0d3b1bce272a5927feaa602dfbcb77",
+        "import_time": "2025-10-30T03:28:38.309211Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@aio-commerce-sdk/config-typescript/MAL-0000-google-open-source-security-529550a59f3693a3.json
+++ b/osv/malicious/npm/@aio-commerce-sdk/config-typescript/MAL-0000-google-open-source-security-529550a59f3693a3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @aio-commerce-sdk/config-typescript (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@aio-commerce-sdk/config-typescript"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "529550a59f3693a31c91c822d84014c55fc2ca0d1e93b1660b9a903d774f1ae8",
+        "import_time": "2025-10-30T03:28:38.314233Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@aio-commerce-sdk/config-vitest/MAL-0000-google-open-source-security-76977e76055a45b2.json
+++ b/osv/malicious/npm/@aio-commerce-sdk/config-vitest/MAL-0000-google-open-source-security-76977e76055a45b2.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @aio-commerce-sdk/config-vitest (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@aio-commerce-sdk/config-vitest"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "76977e76055a45b2efb1a259512cb44d7872d29e9f984724e9d429d7321319fb",
+        "import_time": "2025-10-30T03:28:38.330427Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@amazon-bedrock-agents-healthcare-lifesciences/docs/MAL-0000-google-open-source-security-82a7c84df77738f0.json
+++ b/osv/malicious/npm/@amazon-bedrock-agents-healthcare-lifesciences/docs/MAL-0000-google-open-source-security-82a7c84df77738f0.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @amazon-bedrock-agents-healthcare-lifesciences/docs (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@amazon-bedrock-agents-healthcare-lifesciences/docs"
+      },
+      "versions": [
+        "0.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "82a7c84df77738f022f098cba64fc932aa0121a61c753afcc26fb188469a8276",
+        "import_time": "2025-10-30T03:28:38.335108Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@apache-felix/felix-antora-ui/MAL-0000-google-open-source-security-ec7e227acf32998c.json
+++ b/osv/malicious/npm/@apache-felix/felix-antora-ui/MAL-0000-google-open-source-security-ec7e227acf32998c.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @apache-felix/felix-antora-ui (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@apache-felix/felix-antora-ui"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "ec7e227acf32998c52055538955e0cc4e54b9551273429848a0f3173c3a6231b",
+        "import_time": "2025-10-30T03:28:38.340821Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@apache-netbeans/netbeans-antora-ui/MAL-0000-google-open-source-security-839f29c0e3bb9fe2.json
+++ b/osv/malicious/npm/@apache-netbeans/netbeans-antora-ui/MAL-0000-google-open-source-security-839f29c0e3bb9fe2.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @apache-netbeans/netbeans-antora-ui (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@apache-netbeans/netbeans-antora-ui"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "839f29c0e3bb9fe21ae544d9e87ca4c36939daec4f3216413576d4d10a873bc7",
+        "import_time": "2025-10-30T03:28:38.344998Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@apachesling/slingpackager/MAL-0000-google-open-source-security-375b7a8b5e12a58e.json
+++ b/osv/malicious/npm/@apachesling/slingpackager/MAL-0000-google-open-source-security-375b7a8b5e12a58e.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @apachesling/slingpackager (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@apachesling/slingpackager"
+      },
+      "versions": [
+        "1.0.0",
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "375b7a8b5e12a58e2d9ad67e6273a017b9ad6d82b1fb99483e964937a32b8dc1",
+        "import_time": "2025-10-30T03:28:38.349204Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0",
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@apachesling/slingpost/MAL-0000-google-open-source-security-c6b74080fda6fce3.json
+++ b/osv/malicious/npm/@apachesling/slingpost/MAL-0000-google-open-source-security-c6b74080fda6fce3.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @apachesling/slingpost (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@apachesling/slingpost"
+      },
+      "versions": [
+        "1.0.0",
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c6b74080fda6fce36f37fe56bd48b957be33ca871ed87ce3bd40222091e0c1f0",
+        "import_time": "2025-10-30T03:28:38.353175Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0",
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@dealmgmt/grid/MAL-0000-google-open-source-security-3f1e7bb02af2f24d.json
+++ b/osv/malicious/npm/@dealmgmt/grid/MAL-0000-google-open-source-security-3f1e7bb02af2f24d.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @dealmgmt/grid (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@dealmgmt/grid"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "3f1e7bb02af2f24d6a057db349128269908eb7e771722c7cf8aa637d3974058a",
+        "import_time": "2025-10-30T03:28:38.35788Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@decentraland-gatsby/intl/MAL-0000-google-open-source-security-7879d73b90cf9ff3.json
+++ b/osv/malicious/npm/@decentraland-gatsby/intl/MAL-0000-google-open-source-security-7879d73b90cf9ff3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @decentraland-gatsby/intl (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@decentraland-gatsby/intl"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "7879d73b90cf9ff38512e08bf8b74c2b1d5811f25499c990c33fca2d2052feef",
+        "import_time": "2025-10-30T03:28:38.363409Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@discord-external/activity-iframe-sdk/MAL-0000-google-open-source-security-c4df7af2ceae80fd.json
+++ b/osv/malicious/npm/@discord-external/activity-iframe-sdk/MAL-0000-google-open-source-security-c4df7af2ceae80fd.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @discord-external/activity-iframe-sdk (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@discord-external/activity-iframe-sdk"
+      },
+      "versions": [
+        "2.3.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c4df7af2ceae80fdc052edf95094a378287786ae21cfec9a6104a2af2b1d9b98",
+        "import_time": "2025-10-30T03:28:38.368246Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "2.3.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@dtpk-cc/components/MAL-0000-google-open-source-security-84f899d638c1d22b.json
+++ b/osv/malicious/npm/@dtpk-cc/components/MAL-0000-google-open-source-security-84f899d638c1d22b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @dtpk-cc/components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@dtpk-cc/components"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "84f899d638c1d22b86060ddaa67e28a28f5cd865d4569531493918f5db0a5987",
+        "import_time": "2025-10-30T03:28:38.37324Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@exarad/verfuegbarkeitspruefung-vue2/MAL-0000-google-open-source-security-e559c72bff1b3a96.json
+++ b/osv/malicious/npm/@exarad/verfuegbarkeitspruefung-vue2/MAL-0000-google-open-source-security-e559c72bff1b3a96.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @exarad/verfuegbarkeitspruefung-vue2 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@exarad/verfuegbarkeitspruefung-vue2"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e559c72bff1b3a967efbd6aefbf4978a2ba9a2045ce425232f1c4c88b2b2da0e",
+        "import_time": "2025-10-30T03:28:38.377271Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@foryjs/fory/MAL-0000-google-open-source-security-37cc85bd94dccf14.json
+++ b/osv/malicious/npm/@foryjs/fory/MAL-0000-google-open-source-security-37cc85bd94dccf14.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @foryjs/fory (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@foryjs/fory"
+      },
+      "versions": [
+        "1.0.0",
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "37cc85bd94dccf1460d716d3a603bad10397060a4aa5398b42882110d01cb85b",
+        "import_time": "2025-10-30T03:28:38.383193Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0",
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@foryjs/hps/MAL-0000-google-open-source-security-0194b673bd924b4e.json
+++ b/osv/malicious/npm/@foryjs/hps/MAL-0000-google-open-source-security-0194b673bd924b4e.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @foryjs/hps (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@foryjs/hps"
+      },
+      "versions": [
+        "1.0.0",
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "0194b673bd924b4e8e007349e2af575df749db95449277785f569eb01e5b2005",
+        "import_time": "2025-10-30T03:28:38.388156Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0",
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@gitlab-lsp/pkg-1/MAL-0000-google-open-source-security-3ad685e952ccdbea.json
+++ b/osv/malicious/npm/@gitlab-lsp/pkg-1/MAL-0000-google-open-source-security-3ad685e952ccdbea.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @gitlab-lsp/pkg-1 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@gitlab-lsp/pkg-1"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "3ad685e952ccdbea3c1d03875ee4f21f34d05b813201e1f395b6113282ed0499",
+        "import_time": "2025-10-30T03:28:38.39311Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@gitlab-lsp/pkg-2/MAL-0000-google-open-source-security-746d12a049b7f289.json
+++ b/osv/malicious/npm/@gitlab-lsp/pkg-2/MAL-0000-google-open-source-security-746d12a049b7f289.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @gitlab-lsp/pkg-2 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@gitlab-lsp/pkg-2"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "746d12a049b7f2890ccff33c2ff6cf9af9f68ca307c859348a1e7232b03289bb",
+        "import_time": "2025-10-30T03:28:38.397298Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@gitlab-lsp/workflow-api/MAL-0000-google-open-source-security-d635b036e770ace3.json
+++ b/osv/malicious/npm/@gitlab-lsp/workflow-api/MAL-0000-google-open-source-security-d635b036e770ace3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @gitlab-lsp/workflow-api (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@gitlab-lsp/workflow-api"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d635b036e770ace325f4108e48ce085b5e03a7485776d52f63612a33dc54c571",
+        "import_time": "2025-10-30T03:28:38.402165Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@gitlab-test/bun-v1/MAL-0000-google-open-source-security-b9dbef7fe49e9db3.json
+++ b/osv/malicious/npm/@gitlab-test/bun-v1/MAL-0000-google-open-source-security-b9dbef7fe49e9db3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @gitlab-test/bun-v1 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@gitlab-test/bun-v1"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b9dbef7fe49e9db385a54db30f4fa4831c8829a1f9d51eef955ac30c068e325b",
+        "import_time": "2025-10-30T03:28:38.406261Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@gitlab-test/npm-v10/MAL-0000-google-open-source-security-44ab0564723fe806.json
+++ b/osv/malicious/npm/@gitlab-test/npm-v10/MAL-0000-google-open-source-security-44ab0564723fe806.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @gitlab-test/npm-v10 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@gitlab-test/npm-v10"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "44ab0564723fe80648494df2c98183ad047f8736c04cd4ba47d6691066b3bfa7",
+        "import_time": "2025-10-30T03:28:38.411054Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@gitlab-test/pnpm-v9/MAL-0000-google-open-source-security-d9c9799fde2a1e35.json
+++ b/osv/malicious/npm/@gitlab-test/pnpm-v9/MAL-0000-google-open-source-security-d9c9799fde2a1e35.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @gitlab-test/pnpm-v9 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@gitlab-test/pnpm-v9"
+      },
+      "versions": [
+        "0.3.0",
+        "0.4.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d9c9799fde2a1e35b145abe89a3e4ea853116093591b30048d8ede077e2ca71b",
+        "import_time": "2025-10-30T03:28:38.416207Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0",
+          "0.4.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@gitlab-test/yarn-v4/MAL-0000-google-open-source-security-fb1f71d451b10414.json
+++ b/osv/malicious/npm/@gitlab-test/yarn-v4/MAL-0000-google-open-source-security-fb1f71d451b10414.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @gitlab-test/yarn-v4 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@gitlab-test/yarn-v4"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "fb1f71d451b10414da62531c3319dba3ce1608c322e6c083df33db916ba631b4",
+        "import_time": "2025-10-30T03:28:38.421063Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@i22-td-smarthome/component-library/MAL-0000-google-open-source-security-9e40f13de4ec7332.json
+++ b/osv/malicious/npm/@i22-td-smarthome/component-library/MAL-0000-google-open-source-security-9e40f13de4ec7332.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @i22-td-smarthome/component-library (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@i22-td-smarthome/component-library"
+      },
+      "versions": [
+        "0.7.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "9e40f13de4ec7332b2f634592ba642b1ba716292b141ecc01c5543b087e1a1a3",
+        "import_time": "2025-10-30T03:28:38.425183Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.7.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@i22/rocket/MAL-0000-google-open-source-security-dd25503158a14bdc.json
+++ b/osv/malicious/npm/@i22/rocket/MAL-0000-google-open-source-security-dd25503158a14bdc.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @i22/rocket (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@i22/rocket"
+      },
+      "versions": [
+        "0.7.11"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "dd25503158a14bdc8ee8162d7d0d4f5c76052bf80c454688431484a32ebae7c2",
+        "import_time": "2025-10-30T03:28:38.429449Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.7.11"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@i22/scroll-animation/MAL-0000-google-open-source-security-9c6efc9f3294231e.json
+++ b/osv/malicious/npm/@i22/scroll-animation/MAL-0000-google-open-source-security-9c6efc9f3294231e.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @i22/scroll-animation (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@i22/scroll-animation"
+      },
+      "versions": [
+        "0.1.10"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "9c6efc9f3294231eba3ef1cb2dabc5bdb4d045b640057eae98abc5d79dce9e87",
+        "import_time": "2025-10-30T03:28:38.434231Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.1.10"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@js-to-lua/convert/MAL-0000-google-open-source-security-02a239caab343a54.json
+++ b/osv/malicious/npm/@js-to-lua/convert/MAL-0000-google-open-source-security-02a239caab343a54.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @js-to-lua/convert (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@js-to-lua/convert"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "02a239caab343a546294ddfcdf5a4e7310b52dbda9a131ad2d436b774721fff5",
+        "import_time": "2025-10-30T03:28:38.439094Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@js-to-lua/fast-follow-commands/MAL-0000-google-open-source-security-43bcb68c2e4ef8bf.json
+++ b/osv/malicious/npm/@js-to-lua/fast-follow-commands/MAL-0000-google-open-source-security-43bcb68c2e4ef8bf.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @js-to-lua/fast-follow-commands (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@js-to-lua/fast-follow-commands"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "43bcb68c2e4ef8bf4aa612c6387e55f1995aa48ba1fdd9865a52fdbbe2ebb08c",
+        "import_time": "2025-10-30T03:28:38.444289Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@js-to-lua/handler-utils/MAL-0000-google-open-source-security-459c973bebbfcf09.json
+++ b/osv/malicious/npm/@js-to-lua/handler-utils/MAL-0000-google-open-source-security-459c973bebbfcf09.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @js-to-lua/handler-utils (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@js-to-lua/handler-utils"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "459c973bebbfcf096efa317f0c6bd1a4eebe85c14e373632f601d840ef283618",
+        "import_time": "2025-10-30T03:28:38.448242Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@js-to-lua/lua-conversion-utils/MAL-0000-google-open-source-security-9c20dec1487e2929.json
+++ b/osv/malicious/npm/@js-to-lua/lua-conversion-utils/MAL-0000-google-open-source-security-9c20dec1487e2929.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @js-to-lua/lua-conversion-utils (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@js-to-lua/lua-conversion-utils"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "9c20dec1487e29293508a53ce2e1ca36ba73b11451ee42b3d914cc87e789027f",
+        "import_time": "2025-10-30T03:28:38.452441Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@js-to-lua/lua-types/MAL-0000-google-open-source-security-3ecf90fe25a3fc0a.json
+++ b/osv/malicious/npm/@js-to-lua/lua-types/MAL-0000-google-open-source-security-3ecf90fe25a3fc0a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @js-to-lua/lua-types (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@js-to-lua/lua-types"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "3ecf90fe25a3fc0a3d94258c17a46ce76ec2a5f78cd85c031c2e7373b569b49f",
+        "import_time": "2025-10-30T03:28:38.456411Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@morphodao/morpho-core-v1/MAL-0000-google-open-source-security-b556b3bb1e128644.json
+++ b/osv/malicious/npm/@morphodao/morpho-core-v1/MAL-0000-google-open-source-security-b556b3bb1e128644.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @morphodao/morpho-core-v1 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@morphodao/morpho-core-v1"
+      },
+      "versions": [
+        "0.24.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b556b3bb1e12864483cabd5aa51be2d5c4c5e3ae09c0253921c5078d541fe52d",
+        "import_time": "2025-10-30T03:28:38.462233Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.24.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@msdyn365-commerce-marketplace/address-extensions/MAL-0000-google-open-source-security-bcb3376368c4733f.json
+++ b/osv/malicious/npm/@msdyn365-commerce-marketplace/address-extensions/MAL-0000-google-open-source-security-bcb3376368c4733f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @msdyn365-commerce-marketplace/address-extensions (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@msdyn365-commerce-marketplace/address-extensions"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "bcb3376368c4733f8abe32dffa3e07ef57ca5bb98b66d14c6da4b9d448c95f0b",
+        "import_time": "2025-10-30T03:28:38.467215Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@msdyn365-commerce-marketplace/tax-registration-numbers/MAL-0000-google-open-source-security-f0ce1644cf8c5011.json
+++ b/osv/malicious/npm/@msdyn365-commerce-marketplace/tax-registration-numbers/MAL-0000-google-open-source-security-f0ce1644cf8c5011.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @msdyn365-commerce-marketplace/tax-registration-numbers (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@msdyn365-commerce-marketplace/tax-registration-numbers"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "f0ce1644cf8c501195800c70b0898d075ebc160e49f5028a518eab5864b66481",
+        "import_time": "2025-10-30T03:28:38.472232Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@openzeppelin-compact/compact/MAL-0000-google-open-source-security-d825c14b9737accf.json
+++ b/osv/malicious/npm/@openzeppelin-compact/compact/MAL-0000-google-open-source-security-d825c14b9737accf.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @openzeppelin-compact/compact (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@openzeppelin-compact/compact"
+      },
+      "versions": [
+        "0.24.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d825c14b9737accf6a7459f4860bba3ad88d4e486cc8dbdf823de3c9db859568",
+        "import_time": "2025-10-30T03:28:38.477165Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.24.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@openzeppelin-compact/fungible-token/MAL-0000-google-open-source-security-e818d9cf26ae7eb0.json
+++ b/osv/malicious/npm/@openzeppelin-compact/fungible-token/MAL-0000-google-open-source-security-e818d9cf26ae7eb0.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @openzeppelin-compact/fungible-token (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@openzeppelin-compact/fungible-token"
+      },
+      "versions": [
+        "0.24.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e818d9cf26ae7eb0cd066d3c0e1815ec3644011377ebef5ca45f2025d67c1f50",
+        "import_time": "2025-10-30T03:28:38.482188Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.24.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@openzeppelin-compact/utils/MAL-0000-google-open-source-security-d75b6506ebe35178.json
+++ b/osv/malicious/npm/@openzeppelin-compact/utils/MAL-0000-google-open-source-security-d75b6506ebe35178.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @openzeppelin-compact/utils (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@openzeppelin-compact/utils"
+      },
+      "versions": [
+        "0.24.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d75b6506ebe35178dab0fd07b0d4b6eefa6b589b39be730fa254300e183cb168",
+        "import_time": "2025-10-30T03:28:38.487135Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.24.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@pa-client/power-code-sdk/MAL-0000-google-open-source-security-d4e4e60e81a3f9e3.json
+++ b/osv/malicious/npm/@pa-client/power-code-sdk/MAL-0000-google-open-source-security-d4e4e60e81a3f9e3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @pa-client/power-code-sdk (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@pa-client/power-code-sdk"
+      },
+      "versions": [
+        "0.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d4e4e60e81a3f9e3d09b38449c8306efa17c41542344cdef074a3bb6912a381b",
+        "import_time": "2025-10-30T03:28:38.492076Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@raux/ra-react-big-calendar/MAL-0000-google-open-source-security-2a212e56b9bc45f8.json
+++ b/osv/malicious/npm/@raux/ra-react-big-calendar/MAL-0000-google-open-source-security-2a212e56b9bc45f8.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in @raux/ra-react-big-calendar (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@raux/ra-react-big-calendar"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2a212e56b9bc45f8e1a5ba0e12813f0d333c9d77c3d94b1ec81b8bdd42655580",
+        "import_time": "2025-10-30T03:28:38.496873Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/acme-package/MAL-0000-google-open-source-security-115863c724733756.json
+++ b/osv/malicious/npm/acme-package/MAL-0000-google-open-source-security-115863c724733756.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in acme-package (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "acme-package"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "115863c724733756af194811e4d8792dca84de9a98a8c9cd8d9e014dfc0d8a15",
+        "import_time": "2025-10-30T03:28:38.50252Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/add-module-exports/MAL-0000-google-open-source-security-4039c4a63f281477.json
+++ b/osv/malicious/npm/add-module-exports/MAL-0000-google-open-source-security-4039c4a63f281477.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in add-module-exports (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "add-module-exports"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4039c4a63f281477eaed02400e1eb7714632a6587f1990050b3b7cfb126455c3",
+        "import_time": "2025-10-30T03:28:38.50719Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/add-shopify-header/MAL-0000-google-open-source-security-486da4a50f6390b5.json
+++ b/osv/malicious/npm/add-shopify-header/MAL-0000-google-open-source-security-486da4a50f6390b5.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in add-shopify-header (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "add-shopify-header"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "486da4a50f6390b5c414dbb681546d0ad7b4b83001c65cc11ea7a846647858e7",
+        "import_time": "2025-10-30T03:28:38.512338Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/adobe-alloy-mini-site/MAL-0000-google-open-source-security-d728d9b200c3b588.json
+++ b/osv/malicious/npm/adobe-alloy-mini-site/MAL-0000-google-open-source-security-d728d9b200c3b588.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in adobe-alloy-mini-site (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "adobe-alloy-mini-site"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d728d9b200c3b58899afcf6beb561ec60882028a3368ade745710195d969df22",
+        "import_time": "2025-10-30T03:28:38.522269Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/adobe-alloy/MAL-0000-google-open-source-security-a8e952541082c8be.json
+++ b/osv/malicious/npm/adobe-alloy/MAL-0000-google-open-source-security-a8e952541082c8be.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in adobe-alloy (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "adobe-alloy"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a8e952541082c8bec5f3b5c23a250995aa6d04b35925087502b6ed7100760d27",
+        "import_time": "2025-10-30T03:28:38.517375Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/aikido-module/MAL-0000-google-open-source-security-d5616cbe0ab66ee9.json
+++ b/osv/malicious/npm/aikido-module/MAL-0000-google-open-source-security-d5616cbe0ab66ee9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in aikido-module (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "aikido-module"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d5616cbe0ab66ee9662bda8dd07b357eb52c5094e1a6f367d5b4c16e313aa2c8",
+        "import_time": "2025-10-30T03:28:38.527232Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-angular/MAL-0000-google-open-source-security-7fff1f5000c3707b.json
+++ b/osv/malicious/npm/airbnb-angular/MAL-0000-google-open-source-security-7fff1f5000c3707b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-angular (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-angular"
+      },
+      "versions": [
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "7fff1f5000c3707b881be6257856ad35d4e8c37a27f0219b0e380ee46fcae5ea",
+        "import_time": "2025-10-30T03:28:38.532184Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-babel/MAL-0000-google-open-source-security-42eb2fdb8e5d1d2d.json
+++ b/osv/malicious/npm/airbnb-babel/MAL-0000-google-open-source-security-42eb2fdb8e5d1d2d.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-babel (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-babel"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "42eb2fdb8e5d1d2dbd45978d0cbc48eabb4fd965128cc80a6725c235793bb2fc",
+        "import_time": "2025-10-30T03:28:38.537251Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-base-hf/MAL-0000-google-open-source-security-65b2cddf779ee3b3.json
+++ b/osv/malicious/npm/airbnb-base-hf/MAL-0000-google-open-source-security-65b2cddf779ee3b3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-base-hf (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-base-hf"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "65b2cddf779ee3b3d6e100dd972a58e3d516c91dad0c876d9f7eff615a2d0567",
+        "import_time": "2025-10-30T03:28:38.542251Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-base-typescript-prettier/MAL-0000-google-open-source-security-3205a12e14694a32.json
+++ b/osv/malicious/npm/airbnb-base-typescript-prettier/MAL-0000-google-open-source-security-3205a12e14694a32.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-base-typescript-prettier (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-base-typescript-prettier"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "3205a12e14694a320faeba2a6b56abbf791324aaf4d6c33ee6c3b0e3ef2e1512",
+        "import_time": "2025-10-30T03:28:38.546695Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-bev/MAL-0000-google-open-source-security-58c20a264827fc02.json
+++ b/osv/malicious/npm/airbnb-bev/MAL-0000-google-open-source-security-58c20a264827fc02.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-bev (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-bev"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "58c20a264827fc02c18cb7bad8c41f4c71ab34ca6b30e19198f186cfcf9791b5",
+        "import_time": "2025-10-30T03:28:38.552198Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-bundle/MAL-0000-google-open-source-security-ea6660cd54215b1f.json
+++ b/osv/malicious/npm/airbnb-bundle/MAL-0000-google-open-source-security-ea6660cd54215b1f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-bundle (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-bundle"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "ea6660cd54215b1f9c967e8522156e2728e7ebb64ce3d3052d49f3e41bbffd87",
+        "import_time": "2025-10-30T03:28:38.557097Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-calendar/MAL-0000-google-open-source-security-e80459e015e94c1e.json
+++ b/osv/malicious/npm/airbnb-calendar/MAL-0000-google-open-source-security-e80459e015e94c1e.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-calendar (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-calendar"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e80459e015e94c1ea76d050dbaee456b26ec604089695f1fc7f60dd55ca3cb28",
+        "import_time": "2025-10-30T03:28:38.562229Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-es5/MAL-0000-google-open-source-security-8210336cb16ae642.json
+++ b/osv/malicious/npm/airbnb-es5/MAL-0000-google-open-source-security-8210336cb16ae642.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-es5 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-es5"
+      },
+      "versions": [
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8210336cb16ae6428e936268a05b3f57769d39cfc48cbe662870575dc1faf80b",
+        "import_time": "2025-10-30T03:28:38.567339Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-flow/MAL-0000-google-open-source-security-cf721a7ab34d44cd.json
+++ b/osv/malicious/npm/airbnb-flow/MAL-0000-google-open-source-security-cf721a7ab34d44cd.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-flow (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-flow"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "cf721a7ab34d44cd6e6bd7fa345aa5926234cdaa069ab71e315ee5780227c2b2",
+        "import_time": "2025-10-30T03:28:38.571372Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-hooks/MAL-0000-google-open-source-security-33c430dfd90c926b.json
+++ b/osv/malicious/npm/airbnb-hooks/MAL-0000-google-open-source-security-33c430dfd90c926b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-hooks (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-hooks"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "33c430dfd90c926bae8206a1ac92dcb5b15de7ef7b729c5bc8f88452c6793b44",
+        "import_time": "2025-10-30T03:28:38.576344Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-lite/MAL-0000-google-open-source-security-156283cf217f6dba.json
+++ b/osv/malicious/npm/airbnb-lite/MAL-0000-google-open-source-security-156283cf217f6dba.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-lite (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-lite"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "156283cf217f6dbaa79bc5dfcccb51a8febb9f4a1c0bdaee10e0b65dbae8a32c",
+        "import_time": "2025-10-30T03:28:38.581182Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-opentracing-javascript/MAL-0000-google-open-source-security-f5ddab8a91c87a77.json
+++ b/osv/malicious/npm/airbnb-opentracing-javascript/MAL-0000-google-open-source-security-f5ddab8a91c87a77.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-opentracing-javascript (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-opentracing-javascript"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "f5ddab8a91c87a77ae0ab241ce6ee42b7cc828afe82f980eb531eec7bb9bb296",
+        "import_time": "2025-10-30T03:28:38.585254Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-relaxed/MAL-0000-google-open-source-security-1b6a5e736a13af63.json
+++ b/osv/malicious/npm/airbnb-relaxed/MAL-0000-google-open-source-security-1b6a5e736a13af63.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-relaxed (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-relaxed"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "1b6a5e736a13af63369b9867066a010eb0cb881853407342fe42c472c919dd3c",
+        "import_time": "2025-10-30T03:28:38.589212Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-scraper/MAL-0000-google-open-source-security-005c49bbe176f4a8.json
+++ b/osv/malicious/npm/airbnb-scraper/MAL-0000-google-open-source-security-005c49bbe176f4a8.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-scraper (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-scraper"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "005c49bbe176f4a809d165bd0aff375898fc7fa150bd8d691e4dd1aaa6ff37b2",
+        "import_time": "2025-10-30T03:28:38.594168Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-slider/MAL-0000-google-open-source-security-15aca909831ba643.json
+++ b/osv/malicious/npm/airbnb-slider/MAL-0000-google-open-source-security-15aca909831ba643.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-slider (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-slider"
+      },
+      "versions": [
+        "13.68.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "15aca909831ba6430ae07a33179e67c8aca8a5a631f8bfdf4a3d0f7ad3de3b12",
+        "import_time": "2025-10-30T03:28:38.599415Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "13.68.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-types/MAL-0000-google-open-source-security-4f77c431243e63b6.json
+++ b/osv/malicious/npm/airbnb-types/MAL-0000-google-open-source-security-4f77c431243e63b6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-types (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-types"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4f77c431243e63b694e9abc97e8abec4718f9f4fae5c0c3b620146459ae73872",
+        "import_time": "2025-10-30T03:28:38.605249Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/airbnb-with-tracking/MAL-0000-google-open-source-security-dedc45c8e5c77eb9.json
+++ b/osv/malicious/npm/airbnb-with-tracking/MAL-0000-google-open-source-security-dedc45c8e5c77eb9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in airbnb-with-tracking (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "airbnb-with-tracking"
+      },
+      "versions": [
+        "13.68.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "dedc45c8e5c77eb9d04f659e3e317fea8b51dff4e563c4d09976738a9783b21a",
+        "import_time": "2025-10-30T03:28:38.610545Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "13.68.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/ais-sn-components/MAL-0000-google-open-source-security-4c8c785154de53b3.json
+++ b/osv/malicious/npm/ais-sn-components/MAL-0000-google-open-source-security-4c8c785154de53b3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in ais-sn-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ais-sn-components"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4c8c785154de53b3e480fbfb22a3553c998784ac84e5ea7db72515a9fc21a180",
+        "import_time": "2025-10-30T03:28:38.615222Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/annotate-pure-calls/MAL-0000-google-open-source-security-b499fddd62c6c21d.json
+++ b/osv/malicious/npm/annotate-pure-calls/MAL-0000-google-open-source-security-b499fddd62c6c21d.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in annotate-pure-calls (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "annotate-pure-calls"
+      },
+      "versions": [
+        "9.9.0",
+        "9.9.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b499fddd62c6c21dc104ac400ce7cd4b68302684e9cce162539f96d4ed140fba",
+        "import_time": "2025-10-30T03:28:38.620311Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0",
+          "9.9.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/artifactregistry-login/MAL-0000-google-open-source-security-114cb74707df598c.json
+++ b/osv/malicious/npm/artifactregistry-login/MAL-0000-google-open-source-security-114cb74707df598c.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in artifactregistry-login (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "artifactregistry-login"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "114cb74707df598c5202aee68aa5d00614be3098c16d60bfb565a29b85e76daa",
+        "import_time": "2025-10-30T03:28:38.625283Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/audio-game/MAL-0000-google-open-source-security-44ba9fdb1fb69b10.json
+++ b/osv/malicious/npm/audio-game/MAL-0000-google-open-source-security-44ba9fdb1fb69b10.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in audio-game (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "audio-game"
+      },
+      "versions": [
+        "1.29.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "44ba9fdb1fb69b10b14df19e1e0f3daf4416dedc6f9cb5456c9c5921c59e4b6d",
+        "import_time": "2025-10-30T03:28:38.630429Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.29.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/badgekit-api-client/MAL-0000-google-open-source-security-5694a4080b004915.json
+++ b/osv/malicious/npm/badgekit-api-client/MAL-0000-google-open-source-security-5694a4080b004915.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in badgekit-api-client (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "badgekit-api-client"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "5694a4080b0049154c88e8d438684e6d8beb2f67fcfd03b05f362845834e73f9",
+        "import_time": "2025-10-30T03:28:38.63634Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/braintree-sdk/MAL-0000-google-open-source-security-8aae723475d6edac.json
+++ b/osv/malicious/npm/braintree-sdk/MAL-0000-google-open-source-security-8aae723475d6edac.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in braintree-sdk (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "braintree-sdk"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8aae723475d6edac4690b1bb3767f84cb859705e8bd25dff64fc2d88c7a934b8",
+        "import_time": "2025-10-30T03:28:38.641411Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/chai-friendly/MAL-0000-google-open-source-security-5dba432d6ada382f.json
+++ b/osv/malicious/npm/chai-friendly/MAL-0000-google-open-source-security-5dba432d6ada382f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in chai-friendly (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "chai-friendly"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "5dba432d6ada382f3b0565fa3fc33dddc1bb4752be72eab60eeacf9fac74876e",
+        "import_time": "2025-10-30T03:28:38.647092Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/chromestatus-openapi/MAL-0000-google-open-source-security-cde20ceefa754ec2.json
+++ b/osv/malicious/npm/chromestatus-openapi/MAL-0000-google-open-source-security-cde20ceefa754ec2.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in chromestatus-openapi (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "chromestatus-openapi"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "cde20ceefa754ec2b7386f11a4ca7ca2c8687bfae2c9f048ba8c1a82941e0e5e",
+        "import_time": "2025-10-30T03:28:38.65218Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/cimpress-atsquad/MAL-0000-google-open-source-security-121957f49d6a6452.json
+++ b/osv/malicious/npm/cimpress-atsquad/MAL-0000-google-open-source-security-121957f49d6a6452.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in cimpress-atsquad (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "cimpress-atsquad"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "121957f49d6a6452b17a35ee2371cebf5f74e232fa821e93229fc5f0b2bd720a",
+        "import_time": "2025-10-30T03:28:38.656209Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/closure-es6/MAL-0000-google-open-source-security-e0574a10de5b6d2b.json
+++ b/osv/malicious/npm/closure-es6/MAL-0000-google-open-source-security-e0574a10de5b6d2b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in closure-es6 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "closure-es6"
+      },
+      "versions": [
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e0574a10de5b6d2bca40b32e3869d3a497db2729667e3523f97b8dde3f5846c7",
+        "import_time": "2025-10-30T03:28:38.661326Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/crowdstrike/MAL-0000-google-open-source-security-4c168f4307cd79bd.json
+++ b/osv/malicious/npm/crowdstrike/MAL-0000-google-open-source-security-4c168f4307cd79bd.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in crowdstrike (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "crowdstrike"
+      },
+      "versions": [
+        "3.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4c168f4307cd79bd53a9d823455f09888a554a89baa2eb1e603058b53833d8d0",
+        "import_time": "2025-10-30T03:28:38.667163Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "3.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/discord-open-source/MAL-0000-google-open-source-security-8428b55f07242cb6.json
+++ b/osv/malicious/npm/discord-open-source/MAL-0000-google-open-source-security-8428b55f07242cb6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in discord-open-source (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "discord-open-source"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8428b55f07242cb67f60ccba8d02146498255552e19df02bb8d05fce64279ac3",
+        "import_time": "2025-10-30T03:28:38.671194Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/durablefunctionsmonitor-vscodeext/MAL-0000-google-open-source-security-8b1225e51d4e87fb.json
+++ b/osv/malicious/npm/durablefunctionsmonitor-vscodeext/MAL-0000-google-open-source-security-8b1225e51d4e87fb.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in durablefunctionsmonitor-vscodeext (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "durablefunctionsmonitor-vscodeext"
+      },
+      "versions": [
+        "0.1.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8b1225e51d4e87fbea3405a06a99f4d8b05270acf5c17353ff25be0e73c00daa",
+        "import_time": "2025-10-30T03:28:38.68135Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.1.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/durablefunctionsmonitor.react/MAL-0000-google-open-source-security-cd547e403ab251eb.json
+++ b/osv/malicious/npm/durablefunctionsmonitor.react/MAL-0000-google-open-source-security-cd547e403ab251eb.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in durablefunctionsmonitor.react (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "durablefunctionsmonitor.react"
+      },
+      "versions": [
+        "0.1.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "cd547e403ab251ebc523338bb193135eb564ccea1242d9b159722f211e162aea",
+        "import_time": "2025-10-30T03:28:38.686375Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.1.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/durablefunctionsmonitor/MAL-0000-google-open-source-security-b7cfda0c18c0810f.json
+++ b/osv/malicious/npm/durablefunctionsmonitor/MAL-0000-google-open-source-security-b7cfda0c18c0810f.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in durablefunctionsmonitor (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "durablefunctionsmonitor"
+      },
+      "versions": [
+        "6.7.0",
+        "6.7.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b7cfda0c18c0810ff2d1cbed46aad8a2eed2191975fc316f50f5c40697a1395d",
+        "import_time": "2025-10-30T03:28:38.676112Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "6.7.0",
+          "6.7.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/dynamic-import-node/MAL-0000-google-open-source-security-e6f301178847664c.json
+++ b/osv/malicious/npm/dynamic-import-node/MAL-0000-google-open-source-security-e6f301178847664c.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in dynamic-import-node (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "dynamic-import-node"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e6f301178847664c047f34b5ce64b443f6162b3a0c5113fed22a3a9d1bfcd793",
+        "import_time": "2025-10-30T03:28:38.690029Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/dynamic-import-webpack/MAL-0000-google-open-source-security-6f9cf66ec7ebae84.json
+++ b/osv/malicious/npm/dynamic-import-webpack/MAL-0000-google-open-source-security-6f9cf66ec7ebae84.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in dynamic-import-webpack (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "dynamic-import-webpack"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "6f9cf66ec7ebae846d89e7ce18fbdb1318e4cd99bf61c0e719bd78ce8c6aabe1",
+        "import_time": "2025-10-30T03:28:38.694558Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/e-voting-libraries-ui-kit/MAL-0000-google-open-source-security-00e36fcebf8366e9.json
+++ b/osv/malicious/npm/e-voting-libraries-ui-kit/MAL-0000-google-open-source-security-00e36fcebf8366e9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in e-voting-libraries-ui-kit (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "e-voting-libraries-ui-kit"
+      },
+      "versions": [
+        "9.9.7"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "00e36fcebf8366e9db6eb8a82b38124fb44065faab82afaad3deef53538851fb",
+        "import_time": "2025-10-30T03:28:38.699131Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.7"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/elemefe/MAL-0000-google-open-source-security-bce643418ca7557d.json
+++ b/osv/malicious/npm/elemefe/MAL-0000-google-open-source-security-bce643418ca7557d.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in elemefe (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "elemefe"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "bce643418ca7557d0b7de22ffd4e25e255c713d8f5345b2c8b908b1afcc94285",
+        "import_time": "2025-10-30T03:28:38.704252Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/eslint-comments/MAL-0000-google-open-source-security-54a6c7a3dfcf834b.json
+++ b/osv/malicious/npm/eslint-comments/MAL-0000-google-open-source-security-54a6c7a3dfcf834b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in eslint-comments (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eslint-comments"
+      },
+      "versions": [
+        "9.9.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "54a6c7a3dfcf834b444c7877f39b321d07099d96fcb86b78606c04c68a521432",
+        "import_time": "2025-10-30T03:28:38.708211Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/eslint-config-googlejs-es6/MAL-0000-google-open-source-security-8940b7796dc2789f.json
+++ b/osv/malicious/npm/eslint-config-googlejs-es6/MAL-0000-google-open-source-security-8940b7796dc2789f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in eslint-config-googlejs-es6 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eslint-config-googlejs-es6"
+      },
+      "versions": [
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8940b7796dc2789fa52ad6b2bff9f902eabc3c074e0146ffa0bf81789cc1d365",
+        "import_time": "2025-10-30T03:28:38.713164Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/eslint-disable-next-line/MAL-0000-google-open-source-security-1dc55c7bae0cb903.json
+++ b/osv/malicious/npm/eslint-disable-next-line/MAL-0000-google-open-source-security-1dc55c7bae0cb903.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in eslint-disable-next-line (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eslint-disable-next-line"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "1dc55c7bae0cb90341b9ef16633f9d7bd4057934f0b849ede16f89964146ffc9",
+        "import_time": "2025-10-30T03:28:38.717384Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/eslint-github-bot/MAL-0000-google-open-source-security-2052adffb8b21c64.json
+++ b/osv/malicious/npm/eslint-github-bot/MAL-0000-google-open-source-security-2052adffb8b21c64.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in eslint-github-bot (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eslint-github-bot"
+      },
+      "versions": [
+        "0.1.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2052adffb8b21c64cd38c73e28ba7ae350dfc50f815b318f1e2f4ac999815976",
+        "import_time": "2025-10-30T03:28:38.72215Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.1.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/eslint-plugin-cli-microsoft365/MAL-0000-google-open-source-security-6228651dbd187ec6.json
+++ b/osv/malicious/npm/eslint-plugin-cli-microsoft365/MAL-0000-google-open-source-security-6228651dbd187ec6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in eslint-plugin-cli-microsoft365 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eslint-plugin-cli-microsoft365"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "6228651dbd187ec6a9de497ca258ebc6842617e68a6550d9ecb29ef5a52704de",
+        "import_time": "2025-10-30T03:28:38.727072Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/eslint-plugin-custom-eslint-rules/MAL-0000-google-open-source-security-a21f71ff7d94d7f3.json
+++ b/osv/malicious/npm/eslint-plugin-custom-eslint-rules/MAL-0000-google-open-source-security-a21f71ff7d94d7f3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in eslint-plugin-custom-eslint-rules (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "eslint-plugin-custom-eslint-rules"
+      },
+      "versions": [
+        "0.1.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a21f71ff7d94d7f3fc260b90034dfe9817c30b8e4212aafa96b034e8db138493",
+        "import_time": "2025-10-30T03:28:38.731996Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.1.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/external-helpers/MAL-0000-google-open-source-security-c231c32e17fe4d2d.json
+++ b/osv/malicious/npm/external-helpers/MAL-0000-google-open-source-security-c231c32e17fe4d2d.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in external-helpers (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "external-helpers"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c231c32e17fe4d2ded51e9c8904089cbaed32f3e8b83f02b6294bd4913ed5fc8",
+        "import_time": "2025-10-30T03:28:38.737236Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/faltest/MAL-0000-google-open-source-security-cf2e6442d54e0119.json
+++ b/osv/malicious/npm/faltest/MAL-0000-google-open-source-security-cf2e6442d54e0119.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in faltest (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "faltest"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "cf2e6442d54e01190b02b72dcd576fd4b737fa6d95f7839dcc8e7be290a6e999",
+        "import_time": "2025-10-30T03:28:38.742033Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/fbjs-opensource/MAL-0000-google-open-source-security-2dac438ef7432e16.json
+++ b/osv/malicious/npm/fbjs-opensource/MAL-0000-google-open-source-security-2dac438ef7432e16.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in fbjs-opensource (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "fbjs-opensource"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2dac438ef7432e162ead36cdd4121d9b31b47eaa1eb4ce24c0e577655dc496a5",
+        "import_time": "2025-10-30T03:28:38.747113Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/filename-rules/MAL-0000-google-open-source-security-838053b236472f51.json
+++ b/osv/malicious/npm/filename-rules/MAL-0000-google-open-source-security-838053b236472f51.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in filename-rules (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "filename-rules"
+      },
+      "versions": [
+        "3.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "838053b236472f51d8fac11f9b364eb741bfbf90c3e3c529efe7106dfbe0cbd8",
+        "import_time": "2025-10-30T03:28:38.751904Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "3.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/flowtype-errors/MAL-0000-google-open-source-security-090dd3b0bed74a3f.json
+++ b/osv/malicious/npm/flowtype-errors/MAL-0000-google-open-source-security-090dd3b0bed74a3f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in flowtype-errors (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "flowtype-errors"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "090dd3b0bed74a3f9b2d45d42fc3dbacd94fe75c5628ce85fdb20b86e12db88d",
+        "import_time": "2025-10-30T03:28:38.756898Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/ft-flow/MAL-0000-google-open-source-security-8b0431ce4f8179a1.json
+++ b/osv/malicious/npm/ft-flow/MAL-0000-google-open-source-security-8b0431ce4f8179a1.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in ft-flow (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ft-flow"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8b0431ce4f8179a13d2cbbd1ef51c6132c439dc3ce0af0f28492e50385bf97f1",
+        "import_time": "2025-10-30T03:28:38.762334Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/goji-js-org/MAL-0000-google-open-source-security-986569fbc29022b2.json
+++ b/osv/malicious/npm/goji-js-org/MAL-0000-google-open-source-security-986569fbc29022b2.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in goji-js-org (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "goji-js-org"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "986569fbc29022b242a0f3bc4309cb8213dfe1b9df49c7731ab800653e10ba02",
+        "import_time": "2025-10-30T03:28:38.76698Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/google-cloud-functions-framework/MAL-0000-google-open-source-security-ff13c1c862a7abf6.json
+++ b/osv/malicious/npm/google-cloud-functions-framework/MAL-0000-google-open-source-security-ff13c1c862a7abf6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in google-cloud-functions-framework (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "google-cloud-functions-framework"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "ff13c1c862a7abf603711445585a0c96f0ef4eae31a1c758c504a3871868d061",
+        "import_time": "2025-10-30T03:28:38.771974Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/google-jsdocless/MAL-0000-google-open-source-security-f373d78893327920.json
+++ b/osv/malicious/npm/google-jsdocless/MAL-0000-google-open-source-security-f373d78893327920.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in google-jsdocless (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "google-jsdocless"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "f373d78893327920491950970d76c5deb36859c2cbd890bbc815d16536840004",
+        "import_time": "2025-10-30T03:28:38.776969Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/google-payment/MAL-0000-google-open-source-security-b58f2a2b5e28595f.json
+++ b/osv/malicious/npm/google-payment/MAL-0000-google-open-source-security-b58f2a2b5e28595f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in google-payment (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "google-payment"
+      },
+      "versions": [
+        "999.9.10"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b58f2a2b5e28595f368711ac963cb4060300dc6d5926cc41b20b92296b8ff319",
+        "import_time": "2025-10-30T03:28:38.782159Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "999.9.10"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/image_classification/MAL-0000-google-open-source-security-2a0ffe957ab6c2e9.json
+++ b/osv/malicious/npm/image_classification/MAL-0000-google-open-source-security-2a0ffe957ab6c2e9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in image_classification (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "image_classification"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2a0ffe957ab6c2e9fb1492c23d7606e7f3fc1309606ff32e22e485f21381ecb1",
+        "import_time": "2025-10-30T03:28:38.7871Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/important-stuff/MAL-0000-google-open-source-security-5ea606d0d2b8bbbb.json
+++ b/osv/malicious/npm/important-stuff/MAL-0000-google-open-source-security-5ea606d0d2b8bbbb.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in important-stuff (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "important-stuff"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "5ea606d0d2b8bbbb9232a1de55779bf5b5fff0921ec044a1949cca0b8698cdbc",
+        "import_time": "2025-10-30T03:28:38.791991Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/inline-react-svg/MAL-0000-google-open-source-security-14a3fabe6437c9c5.json
+++ b/osv/malicious/npm/inline-react-svg/MAL-0000-google-open-source-security-14a3fabe6437c9c5.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in inline-react-svg (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "inline-react-svg"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "14a3fabe6437c9c57c964c015ad912f8e84a9f89230e49916f93f027810bc445",
+        "import_time": "2025-10-30T03:28:38.796314Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/internal-test-helpers/MAL-0000-google-open-source-security-200c46d4d97ed899.json
+++ b/osv/malicious/npm/internal-test-helpers/MAL-0000-google-open-source-security-200c46d4d97ed899.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in internal-test-helpers (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "internal-test-helpers"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "200c46d4d97ed899a41a85d503be9a2342145865b3f5018d0045893a8d4585ed",
+        "import_time": "2025-10-30T03:28:38.801064Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/iot-cardboard-js/MAL-0000-google-open-source-security-9b382896d9c38263.json
+++ b/osv/malicious/npm/iot-cardboard-js/MAL-0000-google-open-source-security-9b382896d9c38263.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in iot-cardboard-js (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "iot-cardboard-js"
+      },
+      "versions": [
+        "9.9.0",
+        "9.9.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "9b382896d9c3826352409b09bb0bc65cf20a51ad53f320ec7c19da7da3db0436",
+        "import_time": "2025-10-30T03:28:38.805934Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0",
+          "9.9.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/jest-hoist/MAL-0000-google-open-source-security-147808137c014324.json
+++ b/osv/malicious/npm/jest-hoist/MAL-0000-google-open-source-security-147808137c014324.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in jest-hoist (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jest-hoist"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "147808137c0143246bbd5b1fadeb583902a9baab5144c138a441c1eb0f2b119a",
+        "import_time": "2025-10-30T03:28:38.811271Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/jfrog-npm-actions-example/MAL-0000-google-open-source-security-ad078ca4de541085.json
+++ b/osv/malicious/npm/jfrog-npm-actions-example/MAL-0000-google-open-source-security-ad078ca4de541085.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in jfrog-npm-actions-example (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jfrog-npm-actions-example"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "ad078ca4de541085260ea9b4b8ba08105215c75bc0e17bfa2fa99b0172b40344",
+        "import_time": "2025-10-30T03:28:38.816138Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/jira-ticket-todo-comment/MAL-0000-google-open-source-security-63de970cb9fafbc3.json
+++ b/osv/malicious/npm/jira-ticket-todo-comment/MAL-0000-google-open-source-security-63de970cb9fafbc3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in jira-ticket-todo-comment (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jira-ticket-todo-comment"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "63de970cb9fafbc317d7bc4980ffbbce9bb8a73ea66e51a2c91258adb5eca4bb",
+        "import_time": "2025-10-30T03:28:38.821165Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/jsx-a11y/MAL-0000-google-open-source-security-ff6251c26c99f831.json
+++ b/osv/malicious/npm/jsx-a11y/MAL-0000-google-open-source-security-ff6251c26c99f831.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in jsx-a11y (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "jsx-a11y"
+      },
+      "versions": [
+        "5.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "ff6251c26c99f83167ae029150fcec34bba2dbaa97528a1a1708767fb81a165a",
+        "import_time": "2025-10-30T03:28:38.8262Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "5.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/labelbox-custom-ui/MAL-0000-google-open-source-security-b3a8638d2634c988.json
+++ b/osv/malicious/npm/labelbox-custom-ui/MAL-0000-google-open-source-security-b3a8638d2634c988.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in labelbox-custom-ui (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "labelbox-custom-ui"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b3a8638d2634c98866412434ed066acd37083cf40cf8e5fe088b75a9d083c40c",
+        "import_time": "2025-10-30T03:28:38.830214Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/lion-based-ui-labs/MAL-0000-google-open-source-security-76195255ed7d471f.json
+++ b/osv/malicious/npm/lion-based-ui-labs/MAL-0000-google-open-source-security-76195255ed7d471f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in lion-based-ui-labs (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "lion-based-ui-labs"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "76195255ed7d471f89d1c0685ae2c741539194f0d738c0de2c263de79dffa1bc",
+        "import_time": "2025-10-30T03:28:38.839116Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/lion-based-ui/MAL-0000-google-open-source-security-2ea2067922edf97a.json
+++ b/osv/malicious/npm/lion-based-ui/MAL-0000-google-open-source-security-2ea2067922edf97a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in lion-based-ui (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "lion-based-ui"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2ea2067922edf97a986aeb988010171c7055a76e15b759a5a1eacc8f3c352fe0",
+        "import_time": "2025-10-30T03:28:38.834999Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/minify-dead-code-elimination/MAL-0000-google-open-source-security-4a36a524c2e98fcd.json
+++ b/osv/malicious/npm/minify-dead-code-elimination/MAL-0000-google-open-source-security-4a36a524c2e98fcd.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in minify-dead-code-elimination (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "minify-dead-code-elimination"
+      },
+      "versions": [
+        "9.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4a36a524c2e98fcd3766f1c518cfb706881a5e2b1e9036253e575c7eda0dc35f",
+        "import_time": "2025-10-30T03:28:38.843158Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/mocha-no-only/MAL-0000-google-open-source-security-0f64b8dde070367f.json
+++ b/osv/malicious/npm/mocha-no-only/MAL-0000-google-open-source-security-0f64b8dde070367f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in mocha-no-only (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "mocha-no-only"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "0f64b8dde070367fbf66c7237b89f8caff8fb3bfb461e235eeaf4936fd19c6b4",
+        "import_time": "2025-10-30T03:28:38.847229Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/mourner/MAL-0000-google-open-source-security-8595c02e43c61354.json
+++ b/osv/malicious/npm/mourner/MAL-0000-google-open-source-security-8595c02e43c61354.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in mourner (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "mourner"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8595c02e43c613549f375958850340cc4f8e727350b241081e235ab3ef76e4f1",
+        "import_time": "2025-10-30T03:28:38.851302Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/mycli123/MAL-0000-google-open-source-security-709b10ff3e5a35f6.json
+++ b/osv/malicious/npm/mycli123/MAL-0000-google-open-source-security-709b10ff3e5a35f6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in mycli123 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "mycli123"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "709b10ff3e5a35f672b122eafa6232ae5ba3fef3cc80135a97f709fcd4f70320",
+        "import_time": "2025-10-30T03:28:38.856227Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/named-asset-import/MAL-0000-google-open-source-security-e5e886436476cbb4.json
+++ b/osv/malicious/npm/named-asset-import/MAL-0000-google-open-source-security-e5e886436476cbb4.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in named-asset-import (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "named-asset-import"
+      },
+      "versions": [
+        "0.3.8"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e5e886436476cbb41bd7ef788dd0ebec766824b259f3e45e8089a8c491642375",
+        "import_time": "2025-10-30T03:28:38.861125Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.8"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/netflix-dea/MAL-0000-google-open-source-security-a504842536d8e48d.json
+++ b/osv/malicious/npm/netflix-dea/MAL-0000-google-open-source-security-a504842536d8e48d.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in netflix-dea (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "netflix-dea"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a504842536d8e48df1d91c58d17dcb93fe7876219d0fa0617ec97f2c359f233d",
+        "import_time": "2025-10-30T03:28:38.866196Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/no-floating-promise/MAL-0000-google-open-source-security-c01be231c8c88808.json
+++ b/osv/malicious/npm/no-floating-promise/MAL-0000-google-open-source-security-c01be231c8c88808.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in no-floating-promise (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "no-floating-promise"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c01be231c8c888084f0004d0504f41cacfc405a67146091f2133bf1264f48501",
+        "import_time": "2025-10-30T03:28:38.870946Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/no-only-tests/MAL-0000-google-open-source-security-97eaaf0f1b933033.json
+++ b/osv/malicious/npm/no-only-tests/MAL-0000-google-open-source-security-97eaaf0f1b933033.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in no-only-tests (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "no-only-tests"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "97eaaf0f1b9330331d16b142f1197fef1e0fbfd58a294b271ad47ba8420d1e71",
+        "import_time": "2025-10-30T03:28:38.875136Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/no-unsupported-browser-features/MAL-0000-google-open-source-security-33530062f3f112bc.json
+++ b/osv/malicious/npm/no-unsupported-browser-features/MAL-0000-google-open-source-security-33530062f3f112bc.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in no-unsupported-browser-features (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "no-unsupported-browser-features"
+      },
+      "versions": [
+        "9.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "33530062f3f112bcaf7c108c7d006c3ef590b02ef8e6b8feeba9467aca077e14",
+        "import_time": "2025-10-30T03:28:38.879992Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/oclif-dev/MAL-0000-google-open-source-security-9cf078178f5da452.json
+++ b/osv/malicious/npm/oclif-dev/MAL-0000-google-open-source-security-9cf078178f5da452.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in oclif-dev (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "oclif-dev"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "9cf078178f5da45231528dbb9bb1883266f18b9c8cd4784a7c8542a3c3d4de7b",
+        "import_time": "2025-10-30T03:28:38.884247Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/oclif-typescript/MAL-0000-google-open-source-security-588168406ce54991.json
+++ b/osv/malicious/npm/oclif-typescript/MAL-0000-google-open-source-security-588168406ce54991.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in oclif-typescript (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "oclif-typescript"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "588168406ce54991496f37d72c618c066f9326ccd7d9cf0a774edaf7bc4b4d4f",
+        "import_time": "2025-10-30T03:28:38.889009Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/only-warn/MAL-0000-google-open-source-security-1234a6a6fea01a66.json
+++ b/osv/malicious/npm/only-warn/MAL-0000-google-open-source-security-1234a6a6fea01a66.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in only-warn (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "only-warn"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "1234a6a6fea01a660f3b210279c1aa8e91751f4a76a8cd3ff242b41620465d28",
+        "import_time": "2025-10-30T03:28:38.894028Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/op-cli-installer/MAL-0000-google-open-source-security-126f459a226be8ee.json
+++ b/osv/malicious/npm/op-cli-installer/MAL-0000-google-open-source-security-126f459a226be8ee.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in op-cli-installer (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "op-cli-installer"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "126f459a226be8eeca33508aa9d077f6b5661f085ff20781c5218ced85769480",
+        "import_time": "2025-10-30T03:28:38.898266Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/openzeppelin-compact/MAL-0000-google-open-source-security-c5920997ffc39e89.json
+++ b/osv/malicious/npm/openzeppelin-compact/MAL-0000-google-open-source-security-c5920997ffc39e89.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in openzeppelin-compact (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "openzeppelin-compact"
+      },
+      "versions": [
+        "0.24.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c5920997ffc39e8987ba2fdc7ef62191f9778c3a174ea10e9cc9966775dcfe45",
+        "import_time": "2025-10-30T03:28:38.902894Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.24.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/pensions-portals-fe/MAL-0000-google-open-source-security-641d50f45d5101ba.json
+++ b/osv/malicious/npm/pensions-portals-fe/MAL-0000-google-open-source-security-641d50f45d5101ba.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in pensions-portals-fe (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "pensions-portals-fe"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "641d50f45d5101baaddb0929b0b7a8d3078deb456fc3bb18c4e24f2e0d38d482",
+        "import_time": "2025-10-30T03:28:38.908299Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/petstore-integration-test/MAL-0000-google-open-source-security-96991c4e15df3592.json
+++ b/osv/malicious/npm/petstore-integration-test/MAL-0000-google-open-source-security-96991c4e15df3592.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in petstore-integration-test (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "petstore-integration-test"
+      },
+      "versions": [
+        "1.0.3",
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "96991c4e15df35927756d154bf8d985ad4d42eb85514c35adb2a0cc2bdc7218e",
+        "import_time": "2025-10-30T03:28:38.913292Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.3",
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/playwright-test-plugin/MAL-0000-google-open-source-security-1e6779c473c0002c.json
+++ b/osv/malicious/npm/playwright-test-plugin/MAL-0000-google-open-source-security-1e6779c473c0002c.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in playwright-test-plugin (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "playwright-test-plugin"
+      },
+      "versions": [
+        "1.0.0",
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "1e6779c473c0002c40d1f6d528fa46cd14cea2ce164f86dc3d597743f2150df2",
+        "import_time": "2025-10-30T03:28:38.918078Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0",
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/polyfill-corejs3/MAL-0000-google-open-source-security-44a1f98330311371.json
+++ b/osv/malicious/npm/polyfill-corejs3/MAL-0000-google-open-source-security-44a1f98330311371.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in polyfill-corejs3 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "polyfill-corejs3"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "44a1f983303113714e0d9f44449f37c3e2ab4f3997ffaf3485d4b6dc7027519d",
+        "import_time": "2025-10-30T03:28:38.923238Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/polyfill-regenerator/MAL-0000-google-open-source-security-db6edd5261e12475.json
+++ b/osv/malicious/npm/polyfill-regenerator/MAL-0000-google-open-source-security-db6edd5261e12475.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in polyfill-regenerator (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "polyfill-regenerator"
+      },
+      "versions": [
+        "0.9.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "db6edd5261e124759de0cbbc6ffa360ffdedd3cf4d3fd50d6f2df08278a9a3ae",
+        "import_time": "2025-10-30T03:28:38.927976Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.9.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/powerbi-visuals-sunburst/MAL-0000-google-open-source-security-c4f09341ab079cc6.json
+++ b/osv/malicious/npm/powerbi-visuals-sunburst/MAL-0000-google-open-source-security-c4f09341ab079cc6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in powerbi-visuals-sunburst (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "powerbi-visuals-sunburst"
+      },
+      "versions": [
+        "2.7.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c4f09341ab079cc6ca6651f9ccd4e53457a3ff57b7ec85d32cc7317a8cdc09c7",
+        "import_time": "2025-10-30T03:28:38.932985Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "2.7.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/prefer-arrow/MAL-0000-google-open-source-security-63e5d0bf3c1af92b.json
+++ b/osv/malicious/npm/prefer-arrow/MAL-0000-google-open-source-security-63e5d0bf3c1af92b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in prefer-arrow (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "prefer-arrow"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "63e5d0bf3c1af92b0a085e230f90fee81c3bcf7016c894dd095c11a83acb7f59",
+        "import_time": "2025-10-30T03:28:38.938014Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/prefer-object-spread/MAL-0000-google-open-source-security-2366a56f1a2880b5.json
+++ b/osv/malicious/npm/prefer-object-spread/MAL-0000-google-open-source-security-2366a56f1a2880b5.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in prefer-object-spread (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "prefer-object-spread"
+      },
+      "versions": [
+        "3.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2366a56f1a2880b5b9a925cdf93eb772b2cad44577f23f96a2ee2c26013eedbe",
+        "import_time": "2025-10-30T03:28:38.943045Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "3.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/preferred-import/MAL-0000-google-open-source-security-88b52f1a7d80cbb7.json
+++ b/osv/malicious/npm/preferred-import/MAL-0000-google-open-source-security-88b52f1a7d80cbb7.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in preferred-import (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "preferred-import"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "88b52f1a7d80cbb7e13cd9834387a11ee51778c4b6f724126c5388dba28c3334",
+        "import_time": "2025-10-30T03:28:38.948009Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/react-airbnb-prettier/MAL-0000-google-open-source-security-8dfaae080b90705a.json
+++ b/osv/malicious/npm/react-airbnb-prettier/MAL-0000-google-open-source-security-8dfaae080b90705a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in react-airbnb-prettier (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-airbnb-prettier"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8dfaae080b90705a47740e1ced1edacf0110db947f0f26fdd35e2805a2886d37",
+        "import_time": "2025-10-30T03:28:38.953072Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/react-async-component-lifecycle-hooks/MAL-0000-google-open-source-security-4c15f376ae6ec824.json
+++ b/osv/malicious/npm/react-async-component-lifecycle-hooks/MAL-0000-google-open-source-security-4c15f376ae6ec824.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in react-async-component-lifecycle-hooks (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-async-component-lifecycle-hooks"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4c15f376ae6ec824fa2617999adbe1374d611b505d3aad41141abf419eea97b2",
+        "import_time": "2025-10-30T03:28:38.958019Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/react-important-stuff/MAL-0000-google-open-source-security-668dfcd3b2a7beb6.json
+++ b/osv/malicious/npm/react-important-stuff/MAL-0000-google-open-source-security-668dfcd3b2a7beb6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in react-important-stuff (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-important-stuff"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "668dfcd3b2a7beb6e06018890c297f46d60ea328b837c960b730ad0886a8b0dd",
+        "import_time": "2025-10-30T03:28:38.96384Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/react-naming-convention/MAL-0000-google-open-source-security-1ffbe3fba94b8d1c.json
+++ b/osv/malicious/npm/react-naming-convention/MAL-0000-google-open-source-security-1ffbe3fba94b8d1c.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in react-naming-convention (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-naming-convention"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "1ffbe3fba94b8d1c81b117479b96f278ebe1031ef2935505657c416fcf7f299e",
+        "import_time": "2025-10-30T03:28:38.968983Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/react-web-api/MAL-0000-google-open-source-security-c7f4fc040078e519.json
+++ b/osv/malicious/npm/react-web-api/MAL-0000-google-open-source-security-c7f4fc040078e519.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in react-web-api (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-web-api"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c7f4fc040078e519dbec04d81aa244ab6fb763ffe45c8458c8cc952dd50ca3b9",
+        "import_time": "2025-10-30T03:28:38.973853Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/rushstack-lockfile-explorer/MAL-0000-google-open-source-security-eb4dc0b532660fcd.json
+++ b/osv/malicious/npm/rushstack-lockfile-explorer/MAL-0000-google-open-source-security-eb4dc0b532660fcd.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in rushstack-lockfile-explorer (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "rushstack-lockfile-explorer"
+      },
+      "versions": [
+        "1.2.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "eb4dc0b532660fcd748fd80fd1e79c165c3b614f069745b3f3981e42c04c3f2d",
+        "import_time": "2025-10-30T03:28:38.978198Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.2.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/rxjs-angular/MAL-0000-google-open-source-security-45da4ae77482f3b9.json
+++ b/osv/malicious/npm/rxjs-angular/MAL-0000-google-open-source-security-45da4ae77482f3b9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in rxjs-angular (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "rxjs-angular"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "45da4ae77482f3b92ecf3523c6d1ce7fc133e50f33ddd8b30bce49d2ddae1978",
+        "import_time": "2025-10-30T03:28:38.98297Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/simple-import-sort/MAL-0000-google-open-source-security-99e5c749bd0da9bb.json
+++ b/osv/malicious/npm/simple-import-sort/MAL-0000-google-open-source-security-99e5c749bd0da9bb.json
@@ -1,0 +1,42 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in simple-import-sort (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "simple-import-sort"
+      },
+      "versions": [
+        "10.0.0",
+        "9.9.0",
+        "9.9.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "99e5c749bd0da9bbbe4bf0d2e51df3f104933165f2384958994160d204299459",
+        "import_time": "2025-10-30T03:28:38.988168Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "10.0.0",
+          "9.9.0",
+          "9.9.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/skyscanner-with-prettier/MAL-0000-google-open-source-security-3e078cb63f75c2c9.json
+++ b/osv/malicious/npm/skyscanner-with-prettier/MAL-0000-google-open-source-security-3e078cb63f75c2c9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in skyscanner-with-prettier (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "skyscanner-with-prettier"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "3e078cb63f75c2c9e0d2f46e2c5a351d3a63618d9c13cf6f91e42afd15d7c176",
+        "import_time": "2025-10-30T03:28:38.992201Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/some-other-config-you-use/MAL-0000-google-open-source-security-a98108016141abe1.json
+++ b/osv/malicious/npm/some-other-config-you-use/MAL-0000-google-open-source-security-a98108016141abe1.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in some-other-config-you-use (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "some-other-config-you-use"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a98108016141abe191133227cf47daa98e0d6ebbfd1506d0a5328d80fdee2eb7",
+        "import_time": "2025-10-30T03:28:38.996652Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/sort-class-members/MAL-0000-google-open-source-security-52d90c449ded34fc.json
+++ b/osv/malicious/npm/sort-class-members/MAL-0000-google-open-source-security-52d90c449ded34fc.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in sort-class-members (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "sort-class-members"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "52d90c449ded34fc293ea7deb33cc042140d3adbf969faa1db6bed5c958bb94e",
+        "import_time": "2025-10-30T03:28:39.002179Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/sort-keys-fix/MAL-0000-google-open-source-security-2a52d9a136bf503e.json
+++ b/osv/malicious/npm/sort-keys-fix/MAL-0000-google-open-source-security-2a52d9a136bf503e.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in sort-keys-fix (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "sort-keys-fix"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2a52d9a136bf503e39ec4b5cf7c47664ab41989a3922fa25683fcde419283c28",
+        "import_time": "2025-10-30T03:28:39.007223Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/sort-keys-plus/MAL-0000-google-open-source-security-de24cc6f25fef2ba.json
+++ b/osv/malicious/npm/sort-keys-plus/MAL-0000-google-open-source-security-de24cc6f25fef2ba.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in sort-keys-plus (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "sort-keys-plus"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "de24cc6f25fef2ba921e22810efbaa03b6d2ba2bec94139010b9225f008dbf71",
+        "import_time": "2025-10-30T03:28:39.013493Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/stylelint-config-opbox/MAL-0000-google-open-source-security-7e02ca16874e3af9.json
+++ b/osv/malicious/npm/stylelint-config-opbox/MAL-0000-google-open-source-security-7e02ca16874e3af9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in stylelint-config-opbox (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "stylelint-config-opbox"
+      },
+      "versions": [
+        "3.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "7e02ca16874e3af9774a4294f961e0306827965e363fbb56bcc1b4eb028857a3",
+        "import_time": "2025-10-30T03:28:39.019296Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "3.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/swift-playground-builder/MAL-0000-google-open-source-security-7497eaf30807c4af.json
+++ b/osv/malicious/npm/swift-playground-builder/MAL-0000-google-open-source-security-7497eaf30807c4af.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in swift-playground-builder (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "swift-playground-builder"
+      },
+      "versions": [
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "7497eaf30807c4afb0f3fa20c31f6d49765e5e6ba1af3087e06e22a7b21a6ec1",
+        "import_time": "2025-10-30T03:28:39.024497Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/syntax-dynamic-import/MAL-0000-google-open-source-security-59655611327975ea.json
+++ b/osv/malicious/npm/syntax-dynamic-import/MAL-0000-google-open-source-security-59655611327975ea.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in syntax-dynamic-import (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "syntax-dynamic-import"
+      },
+      "versions": [
+        "10.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "59655611327975ea6cdaf000d3228ec7c5a512f94f4dca7c4da9721b0b717771",
+        "import_time": "2025-10-30T03:28:39.030324Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "10.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/transform-es2015-modules-commonjs/MAL-0000-google-open-source-security-c33050e046d266e7.json
+++ b/osv/malicious/npm/transform-es2015-modules-commonjs/MAL-0000-google-open-source-security-c33050e046d266e7.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in transform-es2015-modules-commonjs (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "transform-es2015-modules-commonjs"
+      },
+      "versions": [
+        "7.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c33050e046d266e711cc220a9365c019fcc6daf0c9f6c1e2be34deddaf636b1c",
+        "import_time": "2025-10-30T03:28:39.035343Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "7.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/transform-merge-sibling-variables/MAL-0000-google-open-source-security-016374451cbae92a.json
+++ b/osv/malicious/npm/transform-merge-sibling-variables/MAL-0000-google-open-source-security-016374451cbae92a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in transform-merge-sibling-variables (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "transform-merge-sibling-variables"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "016374451cbae92ac5aa3924d97f34797cfcf452eb0192c6fcea457f00cca7b6",
+        "import_time": "2025-10-30T03:28:39.040506Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/transform-react-constant-elements/MAL-0000-google-open-source-security-6fe969d8f16b81d6.json
+++ b/osv/malicious/npm/transform-react-constant-elements/MAL-0000-google-open-source-security-6fe969d8f16b81d6.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in transform-react-constant-elements (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "transform-react-constant-elements"
+      },
+      "versions": [
+        "9.9.0",
+        "9.9.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "6fe969d8f16b81d676db0bd27ec296c68913b2b91b30c6dea466da9f94dd62c7",
+        "import_time": "2025-10-30T03:28:39.045225Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0",
+          "9.9.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/transform-react-jsx-source/MAL-0000-google-open-source-security-a4c9e99d75af5207.json
+++ b/osv/malicious/npm/transform-react-jsx-source/MAL-0000-google-open-source-security-a4c9e99d75af5207.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in transform-react-jsx-source (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "transform-react-jsx-source"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a4c9e99d75af5207c128d6ed8e0fdcc05cbf8aa134511214e60ee7ad63232784",
+        "import_time": "2025-10-30T03:28:39.049994Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/transform-react-remove-prop-types/MAL-0000-google-open-source-security-14995787544962db.json
+++ b/osv/malicious/npm/transform-react-remove-prop-types/MAL-0000-google-open-source-security-14995787544962db.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in transform-react-remove-prop-types (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "transform-react-remove-prop-types"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "14995787544962dba56c89a6ef03581d8260232b3479cb3ffc985262d13c6f8f",
+        "import_time": "2025-10-30T03:28:39.054102Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/transform-remove-console/MAL-0000-google-open-source-security-14f63ac75d62e582.json
+++ b/osv/malicious/npm/transform-remove-console/MAL-0000-google-open-source-security-14f63ac75d62e582.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in transform-remove-console (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "transform-remove-console"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "14f63ac75d62e58285432afdb96ca83c925c8f43ad54b0b90b44b15f0b9910d0",
+        "import_time": "2025-10-30T03:28:39.059402Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/transform-strict-mode/MAL-0000-google-open-source-security-35b65030f885c184.json
+++ b/osv/malicious/npm/transform-strict-mode/MAL-0000-google-open-source-security-35b65030f885c184.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in transform-strict-mode (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "transform-strict-mode"
+      },
+      "versions": [
+        "10.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "35b65030f885c1845f271a91ba737e9b6258dce88729a6e0c0359d341ac055c4",
+        "import_time": "2025-10-30T03:28:39.064329Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "10.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/trezor-rollout/MAL-0000-google-open-source-security-43d10b6c89142d33.json
+++ b/osv/malicious/npm/trezor-rollout/MAL-0000-google-open-source-security-43d10b6c89142d33.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in trezor-rollout (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "trezor-rollout"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "43d10b6c89142d3366482472cdaee8c1cc53789da38c306029c240bb45c6b8af",
+        "import_time": "2025-10-30T03:28:39.068213Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/ts-important-stuff/MAL-0000-google-open-source-security-4bcec8cf2c9b3258.json
+++ b/osv/malicious/npm/ts-important-stuff/MAL-0000-google-open-source-security-4bcec8cf2c9b3258.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in ts-important-stuff (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ts-important-stuff"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4bcec8cf2c9b325861d46e800b91f55d0a3ace727e0950dceafbcf1a81a1643d",
+        "import_time": "2025-10-30T03:28:39.073119Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/ts-migrate-example/MAL-0000-google-open-source-security-8942c3f16c8b1325.json
+++ b/osv/malicious/npm/ts-migrate-example/MAL-0000-google-open-source-security-8942c3f16c8b1325.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in ts-migrate-example (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ts-migrate-example"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8942c3f16c8b13252a537d3a5b2b634450826d1c4b8fee64ff88075c52022fcd",
+        "import_time": "2025-10-30T03:28:39.078092Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/ts-react-important-stuff/MAL-0000-google-open-source-security-ee7167da33aba184.json
+++ b/osv/malicious/npm/ts-react-important-stuff/MAL-0000-google-open-source-security-ee7167da33aba184.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in ts-react-important-stuff (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ts-react-important-stuff"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "ee7167da33aba1845c1beb3b62ab4cfd924f77a66a94d644c64fd0d3d1ae912f",
+        "import_time": "2025-10-30T03:28:39.083083Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/twilio-react/MAL-0000-google-open-source-security-b57c2477621c923a.json
+++ b/osv/malicious/npm/twilio-react/MAL-0000-google-open-source-security-b57c2477621c923a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in twilio-react (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "twilio-react"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b57c2477621c923a22979221c79dc7fe06287ee674a3d074ae98b9de612336e2",
+        "import_time": "2025-10-30T03:28:39.088642Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/twilio-ts/MAL-0000-google-open-source-security-73bc44c4e8da604d.json
+++ b/osv/malicious/npm/twilio-ts/MAL-0000-google-open-source-security-73bc44c4e8da604d.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in twilio-ts (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "twilio-ts"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "73bc44c4e8da604dc578bdc525865655656aace99b1b47e4e491624d18fb5b7b",
+        "import_time": "2025-10-30T03:28:39.092932Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/typed-fp/MAL-0000-google-open-source-security-32026d03dbb2c32b.json
+++ b/osv/malicious/npm/typed-fp/MAL-0000-google-open-source-security-32026d03dbb2c32b.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in typed-fp (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "typed-fp"
+      },
+      "versions": [
+        "1.0.0",
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "32026d03dbb2c32bf0168b7b6ffb00772c0c6c07579b114d6c4e1907feedfc49",
+        "import_time": "2025-10-30T03:28:39.098065Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0",
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/typescript-airbnb-prettier-svelte/MAL-0000-google-open-source-security-8b8a76c106576814.json
+++ b/osv/malicious/npm/typescript-airbnb-prettier-svelte/MAL-0000-google-open-source-security-8b8a76c106576814.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in typescript-airbnb-prettier-svelte (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "typescript-airbnb-prettier-svelte"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8b8a76c1065768147b30e3ea2fd6b11214bc8a5ef7181d66f76d2839c3feae34",
+        "import_time": "2025-10-30T03:28:39.107216Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/typescript-airbnb-prettier/MAL-0000-google-open-source-security-48f36cae7e37d50a.json
+++ b/osv/malicious/npm/typescript-airbnb-prettier/MAL-0000-google-open-source-security-48f36cae7e37d50a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in typescript-airbnb-prettier (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "typescript-airbnb-prettier"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "48f36cae7e37d50a38823a30da2b911772c39391c9e15f5aecd255fc8cb37561",
+        "import_time": "2025-10-30T03:28:39.103004Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/typescript-compat/MAL-0000-google-open-source-security-9d51d224698da8c9.json
+++ b/osv/malicious/npm/typescript-compat/MAL-0000-google-open-source-security-9d51d224698da8c9.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in typescript-compat (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "typescript-compat"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "9d51d224698da8c988550237bf4c656382fbd91cf1cd94c75a61d687521763bd",
+        "import_time": "2025-10-30T03:28:39.111056Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/typescript-sort-keys/MAL-0000-google-open-source-security-992172681820d20f.json
+++ b/osv/malicious/npm/typescript-sort-keys/MAL-0000-google-open-source-security-992172681820d20f.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in typescript-sort-keys (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "typescript-sort-keys"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "992172681820d20f522637ebc483c5faf4107be9f86154b177aab06a3225ade9",
+        "import_time": "2025-10-30T03:28:39.115153Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/uach-retrofill/MAL-0000-google-open-source-security-c5b4db27ad78cba8.json
+++ b/osv/malicious/npm/uach-retrofill/MAL-0000-google-open-source-security-c5b4db27ad78cba8.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in uach-retrofill (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "uach-retrofill"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c5b4db27ad78cba86a433f6ca5f9290bcd7d6947c96337aa0af1142b76c026b1",
+        "import_time": "2025-10-30T03:28:39.119045Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/ul-inline/MAL-0000-google-open-source-security-004909dbd53d4f96.json
+++ b/osv/malicious/npm/ul-inline/MAL-0000-google-open-source-security-004909dbd53d4f96.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in ul-inline (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ul-inline"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "004909dbd53d4f9600ce249419320a6da19325303188f67e7390c61ef5bfd203",
+        "import_time": "2025-10-30T03:28:39.12392Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/unused-imports/MAL-0000-google-open-source-security-1d2339df6adcfef3.json
+++ b/osv/malicious/npm/unused-imports/MAL-0000-google-open-source-security-1d2339df6adcfef3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in unused-imports (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "unused-imports"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "1d2339df6adcfef39c5a934840604c6a2fac1a6fbbd2e574388be0a85a250eaf",
+        "import_time": "2025-10-30T03:28:39.128199Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/vscode-notebook-renderer/MAL-0000-google-open-source-security-065f8a29b916aea7.json
+++ b/osv/malicious/npm/vscode-notebook-renderer/MAL-0000-google-open-source-security-065f8a29b916aea7.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in vscode-notebook-renderer (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "vscode-notebook-renderer"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "065f8a29b916aea70aa9f29ac9cde574ebd734c0cd450699387684aa7e3d60fa",
+        "import_time": "2025-10-30T03:28:39.132226Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/vscode.markdown-it-renderer/MAL-0000-google-open-source-security-2822922f8dca5f68.json
+++ b/osv/malicious/npm/vscode.markdown-it-renderer/MAL-0000-google-open-source-security-2822922f8dca5f68.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in vscode.markdown-it-renderer (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "vscode.markdown-it-renderer"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "2822922f8dca5f68d170c921999dd1e45b4dd8b470e088d9aadbe5806cc2069b",
+        "import_time": "2025-10-30T03:28:39.137002Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/vuejs-accessibility/MAL-0000-google-open-source-security-4b6fa70f8b0f650b.json
+++ b/osv/malicious/npm/vuejs-accessibility/MAL-0000-google-open-source-security-4b6fa70f8b0f650b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in vuejs-accessibility (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "vuejs-accessibility"
+      },
+      "versions": [
+        "9.9.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4b6fa70f8b0f650b29ee193a7ba909cab203494e095e6b7054c07a7facd4db5d",
+        "import_time": "2025-10-30T03:28:39.142055Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "9.9.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/wdr-beam/MAL-0000-google-open-source-security-e33b2b91dd8929bf.json
+++ b/osv/malicious/npm/wdr-beam/MAL-0000-google-open-source-security-e33b2b91dd8929bf.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in wdr-beam (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "wdr-beam"
+      },
+      "versions": [
+        "0.3.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e33b2b91dd8929bf5cb832276dd8d1bcfd54958f4868f89e06dae1c45dd2238d",
+        "import_time": "2025-10-30T03:28:39.147053Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "0.3.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/wealthsimple-mcp-server/MAL-0000-google-open-source-security-7cd49239ea1d9566.json
+++ b/osv/malicious/npm/wealthsimple-mcp-server/MAL-0000-google-open-source-security-7cd49239ea1d9566.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in wealthsimple-mcp-server (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "wealthsimple-mcp-server"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "7cd49239ea1d9566f39581393c8553ea1a1733f9ddb3a6dfc09ef5ad0c507122",
+        "import_time": "2025-10-30T03:28:39.152003Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-address-components/MAL-0000-google-open-source-security-be215e94ec6b7be5.json
+++ b/osv/malicious/npm/xo-address-components/MAL-0000-google-open-source-security-be215e94ec6b7be5.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-address-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-address-components"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "be215e94ec6b7be5edeef542a54aea5aea8a1a763873df2e4abd9c77996d6037",
+        "import_time": "2025-10-30T03:28:39.156956Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-beaver/MAL-0000-google-open-source-security-f47822e91a268b85.json
+++ b/osv/malicious/npm/xo-beaver/MAL-0000-google-open-source-security-f47822e91a268b85.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-beaver (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-beaver"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "f47822e91a268b85634963cc1c620bf45c186418ab782e91759b54cb3585ad44",
+        "import_time": "2025-10-30T03:28:39.162055Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-credit-components/MAL-0000-google-open-source-security-bfbd8e01be1c743c.json
+++ b/osv/malicious/npm/xo-credit-components/MAL-0000-google-open-source-security-bfbd8e01be1c743c.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-credit-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-credit-components"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "bfbd8e01be1c743ce546f2b9c82f0c0dc9eed09fc3630a0904a9925eefe0b83f",
+        "import_time": "2025-10-30T03:28:39.166248Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-device-info/MAL-0000-google-open-source-security-b21aa9c7217e181b.json
+++ b/osv/malicious/npm/xo-device-info/MAL-0000-google-open-source-security-b21aa9c7217e181b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-device-info (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-device-info"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b21aa9c7217e181ba3b7126807005d355c23f33f604ce89c30ab72a3af6ea2ae",
+        "import_time": "2025-10-30T03:28:39.170199Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-form-components/MAL-0000-google-open-source-security-784f8f2b24520eb0.json
+++ b/osv/malicious/npm/xo-form-components/MAL-0000-google-open-source-security-784f8f2b24520eb0.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-form-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-form-components"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "784f8f2b24520eb0788e42c94adbe8500c066967520f939829a30a1936d3b093",
+        "import_time": "2025-10-30T03:28:39.175244Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-jquery-mask-plugin/MAL-0000-google-open-source-security-f59460b8ba9281b3.json
+++ b/osv/malicious/npm/xo-jquery-mask-plugin/MAL-0000-google-open-source-security-f59460b8ba9281b3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-jquery-mask-plugin (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-jquery-mask-plugin"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "f59460b8ba9281b320efd1888070928d3c31f86dd0770c7fe38d1f2eecc1e66b",
+        "import_time": "2025-10-30T03:28:39.180238Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-login-components/MAL-0000-google-open-source-security-b3520f298a3dc87b.json
+++ b/osv/malicious/npm/xo-login-components/MAL-0000-google-open-source-security-b3520f298a3dc87b.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-login-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-login-components"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "b3520f298a3dc87bbf78d76824cd0be2b4ea3fbb89e4ff219a3c243094a8cc79",
+        "import_time": "2025-10-30T03:28:39.184867Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-page-components/MAL-0000-google-open-source-security-d5362650ca3f9bc7.json
+++ b/osv/malicious/npm/xo-page-components/MAL-0000-google-open-source-security-d5362650ca3f9bc7.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-page-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-page-components"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d5362650ca3f9bc797008bd2a83e32e9339f75ff840c5ec3868f3931d877fc4a",
+        "import_time": "2025-10-30T03:28:39.190265Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-react/MAL-0000-google-open-source-security-4e894f1b9dae05a3.json
+++ b/osv/malicious/npm/xo-react/MAL-0000-google-open-source-security-4e894f1b9dae05a3.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-react (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-react"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4e894f1b9dae05a3bed6a449b72aa80ec41140feda0bb1bd926380239e701886",
+        "import_time": "2025-10-30T03:28:39.194934Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-shipping-change/MAL-0000-google-open-source-security-084e1b0138282024.json
+++ b/osv/malicious/npm/xo-shipping-change/MAL-0000-google-open-source-security-084e1b0138282024.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-shipping-change (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-shipping-change"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "084e1b0138282024fd6658a0049be6850ce02bf6428041e73ce054120faebab6",
+        "import_time": "2025-10-30T03:28:39.199933Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-shipping-options/MAL-0000-google-open-source-security-8cf812090cb7464d.json
+++ b/osv/malicious/npm/xo-shipping-options/MAL-0000-google-open-source-security-8cf812090cb7464d.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-shipping-options (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-shipping-options"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "8cf812090cb7464d23c98510d2cbcf0b6527aeda2873ae07b4edf3404308f2fb",
+        "import_time": "2025-10-30T03:28:39.204945Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-space/MAL-0000-google-open-source-security-c714200e1f1a835c.json
+++ b/osv/malicious/npm/xo-space/MAL-0000-google-open-source-security-c714200e1f1a835c.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-space (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-space"
+      },
+      "versions": [
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c714200e1f1a835c8bc557fe64c303acb1653f9e6dffcce0bbfa0e1bf1545800",
+        "import_time": "2025-10-30T03:28:39.209979Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-styles/MAL-0000-google-open-source-security-4ef4f18a04a2cab6.json
+++ b/osv/malicious/npm/xo-styles/MAL-0000-google-open-source-security-4ef4f18a04a2cab6.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-styles (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-styles"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "4ef4f18a04a2cab64a90f7140ddbbdfed6f511afaddcec1a6e659965183bbdf0",
+        "import_time": "2025-10-30T03:28:39.214089Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-third-party-components/MAL-0000-google-open-source-security-a0dd2c7952d8a732.json
+++ b/osv/malicious/npm/xo-third-party-components/MAL-0000-google-open-source-security-a0dd2c7952d8a732.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-third-party-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-third-party-components"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a0dd2c7952d8a732029014474709324ad26a8dfab53c898a36d5b415fd154b4c",
+        "import_time": "2025-10-30T03:28:39.218359Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-title/MAL-0000-google-open-source-security-dc97e40614b0dc95.json
+++ b/osv/malicious/npm/xo-title/MAL-0000-google-open-source-security-dc97e40614b0dc95.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-title (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-title"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "dc97e40614b0dc95d4f129429aa92d29e1c8f7c5d794fc062e99797b25160434",
+        "import_time": "2025-10-30T03:28:39.222967Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-tracking/MAL-0000-google-open-source-security-a4263f517bfe1a45.json
+++ b/osv/malicious/npm/xo-tracking/MAL-0000-google-open-source-security-a4263f517bfe1a45.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-tracking (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-tracking"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "a4263f517bfe1a45b0119608b80e754ea85bbc83eba68cfa56c0329fb4696678",
+        "import_time": "2025-10-30T03:28:39.228048Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-typescript/MAL-0000-google-open-source-security-c508442ceff167e8.json
+++ b/osv/malicious/npm/xo-typescript/MAL-0000-google-open-source-security-c508442ceff167e8.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-typescript (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-typescript"
+      },
+      "versions": [
+        "1.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "c508442ceff167e8877a2a098d7b10d4efae92ff3a43987dc031b12771954a4c",
+        "import_time": "2025-10-30T03:28:39.232277Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-ui-components/MAL-0000-google-open-source-security-95e87291251b2845.json
+++ b/osv/malicious/npm/xo-ui-components/MAL-0000-google-open-source-security-95e87291251b2845.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-ui-components (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-ui-components"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "95e87291251b2845b52d8d05eafcd3340241dbcec2f4062e6dfd1ae303b50d96",
+        "import_time": "2025-10-30T03:28:39.236997Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/xo-validation/MAL-0000-google-open-source-security-021827d37008a2ba.json
+++ b/osv/malicious/npm/xo-validation/MAL-0000-google-open-source-security-021827d37008a2ba.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in xo-validation (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "xo-validation"
+      },
+      "versions": [
+        "88.8.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "021827d37008a2ba9f1fe85c99c1e17b9b188c86bcc766680859f7d9bffc8867",
+        "import_time": "2025-10-30T03:28:39.241033Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "88.8.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/yellowcard-styling-config/MAL-0000-google-open-source-security-12dee9a88b4f374a.json
+++ b/osv/malicious/npm/yellowcard-styling-config/MAL-0000-google-open-source-security-12dee9a88b4f374a.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in yellowcard-styling-config (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "yellowcard-styling-config"
+      },
+      "versions": [
+        "1.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "12dee9a88b4f374a8db73de73d255757719bcc1d3124dfe2599b3dbfe3a49d6d",
+        "import_time": "2025-10-30T03:28:39.245969Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "1.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/zohocrm-nodejs-sdk-3.0/MAL-0000-google-open-source-security-249866d4162849db.json
+++ b/osv/malicious/npm/zohocrm-nodejs-sdk-3.0/MAL-0000-google-open-source-security-249866d4162849db.json
@@ -1,0 +1,38 @@
+{
+  "modified": "2025-10-30T03:28:23Z",
+  "published": "2025-10-30T03:28:23Z",
+  "schema_version": "1.5.0",
+  "id": "",
+  "summary": "Malicious code in zohocrm-nodejs-sdk-3.0 (npm)",
+  "details": "This package installs a dependency hosted on a custom domain that runs an\ninfo stealer during installation. The info stealer focuses on stealing\nnpm, git, and other CI/CD related tokens.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "zohocrm-nodejs-sdk-3.0"
+      },
+      "versions": [
+        "99.0.0"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.koi.ai/blog/phantomraven-npm-malware-hidden-in-invisible-dependencies"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "249866d4162849dbcfaf86edff04913ac3fc074fa1f698951cb8c6e9f53b4e9b",
+        "import_time": "2025-10-30T03:28:39.251087Z",
+        "modified_time": "2025-10-30T03:28:23Z",
+        "versions": [
+          "99.0.0"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Most of these already exist. This change adds the Koi article and explicitly lists versions.