### PR TITLE
Remove broken ranges and replace with explicit versions.

### DIFF
--- a/osv/malicious/npm/@cobalt-team/multi-invite/MAL-2022-174.json
+++ b/osv/malicious/npm/@cobalt-team/multi-invite/MAL-2022-174.json
@@ -14,34 +14,14 @@
         "ecosystem": "npm",
         "name": "@cobalt-team/multi-invite"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        },
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.0.1"
-            }
-          ]
-        }
+      "versions": [
+        "1.0.0",
+        "1.0.3",
+        "1.0.4",
+        "1.32.1"
       ],
       "database_specific": {
         "cwes": [
-          {
-            "cweId": "CWE-506",
-            "description": "The product contains code that appears to be malicious in nature.",
-            "name": "Embedded Malicious Code"
-          },
           {
             "cweId": "CWE-506",
             "description": "The product contains code that appears to be malicious in nature.",

--- a/osv/malicious/npm/@cobalt-team/support-email/MAL-2022-175.json
+++ b/osv/malicious/npm/@cobalt-team/support-email/MAL-2022-175.json
@@ -14,34 +14,13 @@
         "ecosystem": "npm",
         "name": "@cobalt-team/support-email"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        },
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "1.0.1"
-            }
-          ]
-        }
+      "versions": [
+        "1.0.0",
+        "1.1.2",
+        "1.54.0"
       ],
       "database_specific": {
         "cwes": [
-          {
-            "cweId": "CWE-506",
-            "description": "The product contains code that appears to be malicious in nature.",
-            "name": "Embedded Malicious Code"
-          },
           {
             "cweId": "CWE-506",
             "description": "The product contains code that appears to be malicious in nature.",


### PR DESCRIPTION
Fixes #934

The ranges did not correctly cover all malicious versions.