### PR TITLE
Add remaining sha1-hulud reports.

### DIFF
--- a/osv/malicious/npm/@lokeswari-satyanarayanan/rn-zustand-expo-template/MAL-0000-google-open-source-security-09bc61c286220568.json
+++ b/osv/malicious/npm/@lokeswari-satyanarayanan/rn-zustand-expo-template/MAL-0000-google-open-source-security-09bc61c286220568.json
@@ -1,0 +1,46 @@
+{
+  "modified": "2025-11-26T02:42:38Z",
+  "published": "2025-11-26T02:42:38Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "summary": "Malicious code in @lokeswari-satyanarayanan/rn-zustand-expo-template (npm)",
+  "details": "This package was compromised by the Sha1-Hulud: The Second Coming NPM worm.\nThe malicious payload steals tokens and credentials and publishes them to\nGitHub. The worm will propogate itself to NPM packages the user owns and\nestablish persistence is a GitHub action.\nThe package may also destroy the user's home directory.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@lokeswari-satyanarayanan/rn-zustand-expo-template"
+      },
+      "versions": [
+        "1.0.9"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "09bc61c286220568e44ddf3190ece908c2158693c4564eb85ff1e7177b9738ae",
+        "import_time": "2025-11-26T02:43:16.433289Z",
+        "modified_time": "2025-11-26T02:42:38Z",
+        "versions": [
+          "1.0.9"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@relyt/claude-context-mcp/MAL-0000-google-open-source-security-e38123c8ca52cb67.json
+++ b/osv/malicious/npm/@relyt/claude-context-mcp/MAL-0000-google-open-source-security-e38123c8ca52cb67.json
@@ -1,0 +1,46 @@
+{
+  "modified": "2025-11-26T02:42:38Z",
+  "published": "2025-11-26T02:42:38Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "summary": "Malicious code in @relyt/claude-context-mcp (npm)",
+  "details": "This package was compromised by the Sha1-Hulud: The Second Coming NPM worm.\nThe malicious payload steals tokens and credentials and publishes them to\nGitHub. The worm will propogate itself to NPM packages the user owns and\nestablish persistence is a GitHub action.\nThe package may also destroy the user's home directory.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@relyt/claude-context-mcp"
+      },
+      "versions": [
+        "0.1.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "e38123c8ca52cb67db0883a996db1e573c1ec2560dfc4f8a39a07eb5ff4ad04b",
+        "import_time": "2025-11-26T02:43:16.451876Z",
+        "modified_time": "2025-11-26T02:42:38Z",
+        "versions": [
+          "0.1.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/@relyt/mcp-server-relytone/MAL-0000-google-open-source-security-279747d06ab008b0.json
+++ b/osv/malicious/npm/@relyt/mcp-server-relytone/MAL-0000-google-open-source-security-279747d06ab008b0.json
@@ -1,0 +1,46 @@
+{
+  "modified": "2025-11-26T02:42:38Z",
+  "published": "2025-11-26T02:42:38Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "summary": "Malicious code in @relyt/mcp-server-relytone (npm)",
+  "details": "This package was compromised by the Sha1-Hulud: The Second Coming NPM worm.\nThe malicious payload steals tokens and credentials and publishes them to\nGitHub. The worm will propogate itself to NPM packages the user owns and\nestablish persistence is a GitHub action.\nThe package may also destroy the user's home directory.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@relyt/mcp-server-relytone"
+      },
+      "versions": [
+        "0.0.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "279747d06ab008b02265ba54afb560bb9e835fdce118f49d4e3bc73ea02b5608",
+        "import_time": "2025-11-26T02:43:16.446608Z",
+        "modified_time": "2025-11-26T02:42:38Z",
+        "versions": [
+          "0.0.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/obj-to-css/MAL-0000-google-open-source-security-ae73874ce6fbb3f8.json
+++ b/osv/malicious/npm/obj-to-css/MAL-0000-google-open-source-security-ae73874ce6fbb3f8.json
@@ -1,0 +1,46 @@
+{
+  "modified": "2025-11-26T02:42:38Z",
+  "published": "2025-11-26T02:42:38Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "summary": "Malicious code in obj-to-css (npm)",
+  "details": "This package was compromised by the Sha1-Hulud: The Second Coming NPM worm.\nThe malicious payload steals tokens and credentials and publishes them to\nGitHub. The worm will propogate itself to NPM packages the user owns and\nestablish persistence is a GitHub action.\nThe package may also destroy the user's home directory.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "obj-to-css"
+      },
+      "versions": [
+        "1.0.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "ae73874ce6fbb3f8c5c8f7ed92b5254aa76f0ff82d5b4413245524a82d21b926",
+        "import_time": "2025-11-26T02:43:16.438807Z",
+        "modified_time": "2025-11-26T02:42:38Z",
+        "versions": [
+          "1.0.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/react-native-phone-call/MAL-0000-google-open-source-security-321a87adb224b335.json
+++ b/osv/malicious/npm/react-native-phone-call/MAL-0000-google-open-source-security-321a87adb224b335.json
@@ -1,0 +1,46 @@
+{
+  "modified": "2025-11-26T02:42:38Z",
+  "published": "2025-11-26T02:42:38Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "summary": "Malicious code in react-native-phone-call (npm)",
+  "details": "This package was compromised by the Sha1-Hulud: The Second Coming NPM worm.\nThe malicious payload steals tokens and credentials and publishes them to\nGitHub. The worm will propogate itself to NPM packages the user owns and\nestablish persistence is a GitHub action.\nThe package may also destroy the user's home directory.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-native-phone-call"
+      },
+      "versions": [
+        "1.2.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "321a87adb224b3356fd38c1c8c2c361ac5b5fdafa51939db383825308ca27237",
+        "import_time": "2025-11-26T02:43:16.423497Z",
+        "modified_time": "2025-11-26T02:42:38Z",
+        "versions": [
+          "1.2.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/react-native-view-finder/MAL-0000-google-open-source-security-d3c1e03e11b15f2f.json
+++ b/osv/malicious/npm/react-native-view-finder/MAL-0000-google-open-source-security-d3c1e03e11b15f2f.json
@@ -1,0 +1,46 @@
+{
+  "modified": "2025-11-26T02:42:38Z",
+  "published": "2025-11-26T02:42:38Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "summary": "Malicious code in react-native-view-finder (npm)",
+  "details": "This package was compromised by the Sha1-Hulud: The Second Coming NPM worm.\nThe malicious payload steals tokens and credentials and publishes them to\nGitHub. The worm will propogate itself to NPM packages the user owns and\nestablish persistence is a GitHub action.\nThe package may also destroy the user's home directory.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-native-view-finder"
+      },
+      "versions": [
+        "1.2.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "d3c1e03e11b15f2fd7c5fee65625b5e46f96f558fbc194cf73967c550769e2a8",
+        "import_time": "2025-11-26T02:43:16.442718Z",
+        "modified_time": "2025-11-26T02:42:38Z",
+        "versions": [
+          "1.2.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/set-nested-prop/MAL-0000-google-open-source-security-065bce4088a0383e.json
+++ b/osv/malicious/npm/set-nested-prop/MAL-0000-google-open-source-security-065bce4088a0383e.json
@@ -1,0 +1,46 @@
+{
+  "modified": "2025-11-26T02:42:38Z",
+  "published": "2025-11-26T02:42:38Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "summary": "Malicious code in set-nested-prop (npm)",
+  "details": "This package was compromised by the Sha1-Hulud: The Second Coming NPM worm.\nThe malicious payload steals tokens and credentials and publishes them to\nGitHub. The worm will propogate itself to NPM packages the user owns and\nestablish persistence is a GitHub action.\nThe package may also destroy the user's home directory.\n",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "set-nested-prop"
+      },
+      "versions": [
+        "2.0.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.aikido.dev/blog/shai-hulud-strikes-again-hitting-zapier-ensdomains"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "065bce4088a0383e36d16e059774b751a30e4b4ab6035954d1ed2fe553b25402",
+        "import_time": "2025-11-26T02:43:16.429063Z",
+        "modified_time": "2025-11-26T02:42:38Z",
+        "versions": [
+          "2.0.2"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add some more reports for packages we have since identified as being compromised by the Sha1-hulud worm.

All except one was already present. This change adds some more details and explicit version information.