### PR TITLE
Add a cooldown to dependabot config.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: "/"
+  cooldown:
+    default-days: 14
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
@@ -13,6 +15,8 @@ updates:
         - patch
 - package-ecosystem: "github-actions"
   directory: "/"
+  cooldown:
+    default-days: 14
   schedule:
     interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
Avoid malicious dependencies from being picked by only updating deps after 14 days.