### PR TITLE
Update MAL-2024-2350.json

### DIFF
--- a/osv/malicious/npm/exceptiongroup/MAL-2024-2350.json
+++ b/osv/malicious/npm/exceptiongroup/MAL-2024-2350.json
@@ -27,8 +27,7 @@
         }
       ],
       "versions": [
-        "1.1.3",
-        "10.1.1"
+        "0.1.1"
       ],
       "database_specific": {
         "cwes": [


### PR DESCRIPTION
The json showed two versions are mal for exceptiongroup, when in reality its just one version which is 0.1.1 https://www.npmjs.com/package/exceptiongroup?activeTab=versions the second version, which was 1.1.3 is listed as mal for pypi/exceptiongroup.  https://pypi.org/project/exceptiongroup/1.1.3/

npm/exceptiongroup-1.1.3 doesnt exist. its pypi/exceptiongroup-1.1.3 and npm/exceptiongroup-1.1.3

Ps. Need to also check for pypi if the entry for exceptiongroup is available. Will check shortly