### PR TITLE
Correct package name blocking ingestion in MAL-2024-12256.json

### DIFF
--- a/osv/malicious/pypi/discord-embedbuilder/MAL-2024-12256.json
+++ b/osv/malicious/pypi/discord-embedbuilder/MAL-2024-12256.json
@@ -9,7 +9,7 @@
     {
       "package": {
         "ecosystem": "PyPI",
-        "name": "Discord-EmbedBuilder"
+        "name": "discord-embedbuilder"
       },
       "ranges": [
         {


### PR DESCRIPTION
This is reincarnation of #1094 When working on fixes for cases like #1104, the report with the normalized name was updated to include versions, and then ingested. This has caused the block again. Looking at the root cause, the non-standardized name was actually introduced by another report from my collection - my database had duplicated normalized and non-normalized entries for this package and published two reports instead of one.

I have removed the invalid entry from my DB, and to ensure further compatibility, I want to fix the name in the MAL-2024-12256 entry to be in the normalized form