### PR TITLE
added malicious sympy-dev package

### DIFF
--- a/osv/malicious/pypi/sympy-dev/MAL-0000-sympy-dev.json
+++ b/osv/malicious/pypi/sympy-dev/MAL-0000-sympy-dev.json
@@ -1,0 +1,40 @@
+{
+  "modified": "2026-01-22T08:18:08Z",
+  "published": "2026-01-22T08:18:08Z",
+  "schema_version": "1.6.8",
+  "summary": "Malicious code in sympy-dev package (PyPI)",
+  "details": "Package downloads and executes code from remote servers, indicating malicious behavior. Multiple files and IPs involved. Package impersonates popular sympy package.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "sympy-dev"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://app.safedep.io/community/malysis/01KF6A8XK4K2H7DWE27QVQE6S2"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Package is malicious:

`sympy/polys/polyroots.py` and `sympy/polys/polytools.py` download and execute code from remote servers (`185.167.99.46` and `63.250.56.54` respectively)

Package also impersonates legit `sympy` python package. 

<img width="1431" height="635" alt="Screenshot_2026-01-22_13-50-54" src="https://github.com/user-attachments/assets/dfe95010-cb92-4f45-9bdb-73b46dbd6868" />
