### PR TITLE
fix: scope @browserbasehq/* advisories to only compromised versions

### DIFF
--- a/osv/malicious/npm/@browserbasehq/bb9/MAL-2025-191193.json
+++ b/osv/malicious/npm/@browserbasehq/bb9/MAL-2025-191193.json
@@ -14,16 +14,6 @@
         "ecosystem": "npm",
         "name": "@browserbasehq/bb9"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
       "versions": [
         "1.2.21"
       ],
@@ -82,15 +72,8 @@
         "import_time": "2025-11-25T00:47:38.435172124Z",
         "id": "GHSA-xxg4-p932-cqpg",
         "modified_time": "2025-11-25T00:07:08Z",
-        "ranges": [
-          {
-            "type": "SEMVER",
-            "events": [
-              {
-                "introduced": "0"
-              }
-            ]
-          }
+        "versions": [
+          "1.2.21"
         ]
       },
       {

--- a/osv/malicious/npm/@browserbasehq/director-ai/MAL-2025-191194.json
+++ b/osv/malicious/npm/@browserbasehq/director-ai/MAL-2025-191194.json
@@ -14,16 +14,6 @@
         "ecosystem": "npm",
         "name": "@browserbasehq/director-ai"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
       "versions": [
         "1.0.3"
       ],
@@ -82,15 +72,8 @@
         "import_time": "2025-11-25T00:47:38.323163103Z",
         "id": "GHSA-h638-vgm6-2xm2",
         "modified_time": "2025-11-25T00:07:44Z",
-        "ranges": [
-          {
-            "type": "SEMVER",
-            "events": [
-              {
-                "introduced": "0"
-              }
-            ]
-          }
+        "versions": [
+          "1.0.3"
         ]
       },
       {

--- a/osv/malicious/npm/@browserbasehq/mcp/MAL-2025-191195.json
+++ b/osv/malicious/npm/@browserbasehq/mcp/MAL-2025-191195.json
@@ -14,16 +14,6 @@
         "ecosystem": "npm",
         "name": "@browserbasehq/mcp"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
       "versions": [
         "2.1.1"
       ],
@@ -82,15 +72,8 @@
         "import_time": "2025-11-25T00:47:38.337313247Z",
         "id": "GHSA-j9hg-hmwf-9qx7",
         "modified_time": "2025-11-25T00:08:14Z",
-        "ranges": [
-          {
-            "type": "SEMVER",
-            "events": [
-              {
-                "introduced": "0"
-              }
-            ]
-          }
+        "versions": [
+          "2.1.1"
         ]
       },
       {

--- a/osv/malicious/npm/@browserbasehq/stagehand-docs/MAL-2025-191199.json
+++ b/osv/malicious/npm/@browserbasehq/stagehand-docs/MAL-2025-191199.json
@@ -14,16 +14,6 @@
         "ecosystem": "npm",
         "name": "@browserbasehq/stagehand-docs"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
       "versions": [
         "1.0.1"
       ],
@@ -82,15 +72,8 @@
         "import_time": "2025-11-25T00:47:38.191131824Z",
         "id": "GHSA-4rjx-92xj-8cj8",
         "modified_time": "2025-11-25T00:08:58Z",
-        "ranges": [
-          {
-            "type": "SEMVER",
-            "events": [
-              {
-                "introduced": "0"
-              }
-            ]
-          }
+        "versions": [
+          "1.0.1"
         ]
       },
       {


### PR DESCRIPTION
## Summary

Removes overly broad SEMVER ranges (`"introduced": "0"`) from 4 `@browserbasehq/*` advisories. Only a single version of each package was compromised during the Shai-Hulud 2.0 attack (Nov 2025). The broad ranges cause tools consuming OSV data (e.g., [Goose](https://github.com/block/goose)) to incorrectly flag **all** versions as malicious, including current clean releases.

## Changes

For each of the 4 affected advisories:
- Removed the overly broad `ranges` field from `affected[0]` (which said all versions `>= 0` are malicious)
- Replaced the broad `ranges` in the `ghsa-malware` origin under `database_specific` with `versions` matching the single compromised version
- The `versions` field in `affected[0]` was already correct and unchanged

| Advisory | Package | Only Malicious Version |
|----------|---------|----------------------|
| MAL-2025-191193 | `@browserbasehq/bb9` | `1.2.21` |
| MAL-2025-191194 | `@browserbasehq/director-ai` | `1.0.3` |
| MAL-2025-191195 | `@browserbasehq/mcp` | `2.1.1` |
| MAL-2025-191199 | `@browserbasehq/stagehand-docs` | `1.0.1` |

The other 3 `@browserbasehq/*` advisories (MAL-2025-191196, MAL-2025-191197, MAL-2025-191198) already had correctly scoped `versions`-only entries and did not need changes.

## Context

- Tracking issue: #1138
- GHSA correction request: https://github.com/github/advisory-database/issues/6993
- The `google-open-source-security` and `amazon-inspector` sources in each advisory already correctly identified only the single compromised version — only the `ghsa-malware` source contributed the overly broad range