### PR TITLE
fix(@cap-js): remove open-ended SEMVER ranges for db-service, postgres, sqlite

### DIFF
--- a/osv/malicious/npm/@cap-js/db-service/MAL-2026-3176.json
+++ b/osv/malicious/npm/@cap-js/db-service/MAL-2026-3176.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-04-29T10:00:00Z",
+  "modified": "2026-04-30T00:00:00Z",
   "published": "2026-04-29T10:00:00Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-3176",
@@ -11,16 +11,6 @@
         "ecosystem": "npm",
         "name": "@cap-js/db-service"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "2.10.1"
-            }
-          ]
-        }
-      ],
       "versions": [
         "2.10.1"
       ]

--- a/osv/malicious/npm/@cap-js/postgres/MAL-2026-3177.json
+++ b/osv/malicious/npm/@cap-js/postgres/MAL-2026-3177.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-04-29T10:00:00Z",
+  "modified": "2026-04-30T00:00:00Z",
   "published": "2026-04-29T10:00:00Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-3177",
@@ -11,16 +11,6 @@
         "ecosystem": "npm",
         "name": "@cap-js/postgres"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "2.2.2"
-            }
-          ]
-        }
-      ],
       "versions": [
         "2.2.2"
       ]

--- a/osv/malicious/npm/@cap-js/sqlite/MAL-2026-3178.json
+++ b/osv/malicious/npm/@cap-js/sqlite/MAL-2026-3178.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-04-29T10:00:00Z",
+  "modified": "2026-04-30T00:00:00Z",
   "published": "2026-04-29T10:00:00Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-3178",
@@ -11,16 +11,6 @@
         "ecosystem": "npm",
         "name": "@cap-js/sqlite"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "2.2.2"
-            }
-          ]
-        }
-      ],
       "versions": [
         "2.2.2"
       ]


### PR DESCRIPTION
The current OSV entries for three `@cap-js` packages contain open-ended SEMVER ranges (`introduced: X` without a `last_affected` or `fixed`) that flag **all versions >= the compromised version** as malicious. This causes false positives for all users who have upgraded past the compromised version.

Clean fixed versions have since been published by the legitimate SAP maintainers.

Removed the `ranges` block from all three affected entries, keeping only the explicit `versions` list.
