### PR TITLE
Update MAL-2026-3463.json to remove ranges

### DIFF
--- a/osv/malicious/npm/@tanstack/history/MAL-2026-3463.json
+++ b/osv/malicious/npm/@tanstack/history/MAL-2026-3463.json
@@ -14,16 +14,6 @@
         "ecosystem": "npm",
         "name": "@tanstack/history"
       },
-      "ranges": [
-        {
-          "type": "SEMVER",
-          "events": [
-            {
-              "introduced": "0"
-            }
-          ]
-        }
-      ],
       "versions": [
         "1.161.12",
         "1.161.9"
@@ -51,16 +41,6 @@
         "id": "GHSA-rmmr-r34h-pfm5",
         "import_time": "2026-05-12T01:08:51.488494118Z",
         "modified_time": "2026-05-12T00:02:46Z",
-        "ranges": [
-          {
-            "events": [
-              {
-                "introduced": "0"
-              }
-            ],
-            "type": "SEMVER"
-          }
-        ],
         "sha256": "d40d7bafa18dd8987c0ee75b8ffccfc7db076f4521961472d0830ef93a03994e",
         "source": "ghsa-malware",
         "versions": [


### PR DESCRIPTION
This pull request makes a small change to the `MAL-2026-3463.json` OSV advisory for the `@tanstack/history` npm package. The change removes the `ranges` field, which previously specified a semver range for affected versions. The advisory now relies solely on the explicit list of affected versions.

- Removed the `ranges` field specifying a semver range from the affected package and related references in the advisory, leaving only the explicit `versions` list. [[1]](diffhunk://#diff-a49db4196ae51e44a71372153b3cd07e3a87697e3eb78611e4ce5ffe55939810L17-L26) [[2]](diffhunk://#diff-a49db4196ae51e44a71372153b3cd07e3a87697e3eb78611e4ce5ffe55939810L54-L63)

Refer to : https://github.com/google/osv.dev/issues/5342