### PR TITLE
Mark withdrawn Puppeteer malware advisories

### DIFF
--- a/osv/malicious/npm/@puppeteer/browsers/MAL-2026-3654.json
+++ b/osv/malicious/npm/@puppeteer/browsers/MAL-2026-3654.json
@@ -1,6 +1,7 @@
 {
   "modified": "2026-05-13T13:11:27Z",
   "published": "2026-05-13T13:11:26Z",
+  "withdrawn": "2026-05-13T19:55:59Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-3654",
   "aliases": [

--- a/osv/malicious/npm/puppeteer-core/MAL-2026-3655.json
+++ b/osv/malicious/npm/puppeteer-core/MAL-2026-3655.json
@@ -1,6 +1,7 @@
 {
   "modified": "2026-05-13T13:21:56Z",
   "published": "2026-05-13T13:21:56Z",
+  "withdrawn": "2026-05-13T19:56:02Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-3655",
   "aliases": [


### PR DESCRIPTION
## Summary

Marks the two withdrawn Puppeteer malware advisories as withdrawn in OSV metadata:

- `MAL-2026-3654` / `GHSA-grrc-v84p-qwv3`
- `MAL-2026-3655` / `GHSA-rvxm-vq55-8p53`

Both GHSA advisories were withdrawn as false positives.

## Changes

- Added `withdrawn: "2026-05-13T19:55:59Z"` to `MAL-2026-3654.json`
- Added `withdrawn: "2026-05-13T19:56:02Z"` to `MAL-2026-3655.json`

Fixes https://github.com/ossf/malicious-packages/issues/1252