### PR TITLE
Add npm RAT malware from OX Security report

### DIFF
--- a/osv/malicious/npm/pinno-loggers/MAL-0000-pinno-loggers.json
+++ b/osv/malicious/npm/pinno-loggers/MAL-0000-pinno-loggers.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-05-20T08:33:16Z",
+  "published": "2026-05-20T08:33:15Z",
+  "schema_version": "1.7.4",
+  "details": "pinno-loggers is a malicious npm package that depends on terminal-logger-utils and triggers the malicious behavior in that package when installed or imported.\n\nThe terminal-logger-utils payload executes a postinstall hook that opens utils.cjs, an obfuscated malware dropper. The dropper downloads and runs a platform-specific second-stage binary from Hugging Face. The second-stage payload provides keylogger, infostealer, and RAT behavior, steals sensitive local data including Telegram Desktop sessions, browser login databases, crypto wallets, SSH keys, cloud configurations, environment variables, and keyword-matched files, and connects to a remote server for full machine control.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "pinno-loggers"
+      },
+      "versions": [
+        "1.0.0"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.ox.security/blog/north-korean-npm-infostealer-rat/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "OX Security",
+      "type": "FINDER",
+      "contact": [
+        "https://www.ox.security/"
+      ]
+    }
+  ]
+}

--- a/osv/malicious/npm/pretty-logger-utils/MAL-0000-pretty-logger-utils.json
+++ b/osv/malicious/npm/pretty-logger-utils/MAL-0000-pretty-logger-utils.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-05-20T08:21:37Z",
+  "published": "2026-05-20T08:21:37Z",
+  "schema_version": "1.7.4",
+  "details": "pretty-logger-utils is a malicious npm package that depends on terminal-logger-utils and triggers the malicious behavior in that package when installed or imported.\n\nThe terminal-logger-utils payload executes a postinstall hook that opens utils.cjs, an obfuscated malware dropper. The dropper downloads and runs a platform-specific second-stage binary from Hugging Face. The second-stage payload provides keylogger, infostealer, and RAT behavior, steals sensitive local data including Telegram Desktop sessions, browser login databases, crypto wallets, SSH keys, cloud configurations, environment variables, and keyword-matched files, and connects to a remote server for full machine control.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "pretty-logger-utils"
+      },
+      "versions": [
+        "1.0.0"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.ox.security/blog/north-korean-npm-infostealer-rat/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "OX Security",
+      "type": "FINDER",
+      "contact": [
+        "https://www.ox.security/"
+      ]
+    }
+  ]
+}

--- a/osv/malicious/npm/terminal-logger-utils/MAL-0000-terminal-logger-utils.json
+++ b/osv/malicious/npm/terminal-logger-utils/MAL-0000-terminal-logger-utils.json
@@ -1,0 +1,42 @@
+{
+  "modified": "2026-05-20T11:00:23Z",
+  "published": "2026-05-20T06:43:15Z",
+  "schema_version": "1.7.4",
+  "details": "terminal-logger-utils is a malicious npm package that when installed executes a postinstall hook that opens utils.cjs, an obfuscated malware dropper. The dropper checks the current system, downloads a platform-specific second-stage binary from Hugging Face, and executes it.\n\nThe second-stage payload is a bundled Node.js executable with embedded malicious JavaScript that provides keylogger, infostealer, and RAT behavior. It collects clipboard and keyboard events, tracks password-field typing, steals sensitive local data including Telegram Desktop sessions, browser login databases, crypto wallets, SSH keys, cloud configurations, environment variables, and keyword-matched files, and connects to a remote server for full machine control.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "terminal-logger-utils"
+      },
+      "versions": [
+        "1.1.0",
+        "1.1.1"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.ox.security/blog/north-korean-npm-infostealer-rat/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "OX Security",
+      "type": "FINDER",
+      "contact": [
+        "https://www.ox.security/"
+      ]
+    }
+  ]
+}

--- a/osv/malicious/npm/ts-logger-pack/MAL-0000-ts-logger-pack.json
+++ b/osv/malicious/npm/ts-logger-pack/MAL-0000-ts-logger-pack.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-05-20T06:52:04Z",
+  "published": "2026-05-20T06:52:04Z",
+  "schema_version": "1.7.4",
+  "details": "ts-logger-pack is a malicious npm package that depends on terminal-logger-utils and triggers the malicious behavior in that package when installed or imported.\n\nThe terminal-logger-utils payload executes a postinstall hook that opens utils.cjs, an obfuscated malware dropper. The dropper downloads and runs a platform-specific second-stage binary from Hugging Face. The second-stage payload provides keylogger, infostealer, and RAT behavior, steals sensitive local data including Telegram Desktop sessions, browser login databases, crypto wallets, SSH keys, cloud configurations, environment variables, and keyword-matched files, and connects to a remote server for full machine control.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ts-logger-pack"
+      },
+      "versions": [
+        "1.1.3"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://www.ox.security/blog/north-korean-npm-infostealer-rat/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "OX Security",
+      "type": "FINDER",
+      "contact": [
+        "https://www.ox.security/"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adding the npm malware packages for
terminal-logger-utils
ts-logger-pack
pinno-loggers
pretty-logger-utils

Where terminal-logger-utils contains a 2nd stage dropper with a RAT payload, all linked back to DPRK, other packages import the terminal-logger-utils package for an indirect execution of the malware.

Link to the report
https://www.ox.security/blog/north-korean-npm-infostealer-rat/