### PR TITLE
Add IronWorm reports links and missing packages.

### DIFF
--- a/osv/malicious/npm/ai3/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/ai3/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ai3"
+      },
+      "versions": [
+        "0.3.5"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.3.5"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/aonote/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/aonote/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "aonote"
+      },
+      "versions": [
+        "0.11.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.11.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/arjson/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/arjson/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "arjson"
+      },
+      "versions": [
+        "0.1.4"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.4"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/arnext-arkb/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/arnext-arkb/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "arnext-arkb"
+      },
+      "versions": [
+        "0.0.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.0.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/arnext/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/arnext/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "arnext"
+      },
+      "versions": [
+        "0.1.5"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.5"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/atomic-notes/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/atomic-notes/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "atomic-notes"
+      },
+      "versions": [
+        "0.5.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.5.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/create-arnext-app/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/create-arnext-app/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "create-arnext-app"
+      },
+      "versions": [
+        "0.0.10"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.0.10"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/cwao-tools/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/cwao-tools/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "cwao-tools"
+      },
+      "versions": [
+        "0.3.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.3.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/cwao-units/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/cwao-units/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "cwao-units"
+      },
+      "versions": [
+        "0.8.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.8.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/cwao/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/cwao/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "cwao"
+      },
+      "versions": [
+        "0.5.6"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.5.6"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/fpjson-lang/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/fpjson-lang/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "fpjson-lang"
+      },
+      "versions": [
+        "0.1.7"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.7"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/hbsig/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/hbsig/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "hbsig"
+      },
+      "versions": [
+        "0.3.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.3.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/monade/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/monade/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "monade"
+      },
+      "versions": [
+        "0.0.7"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.0.7"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/roidjs/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/roidjs/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "roidjs"
+      },
+      "versions": [
+        "0.1.7"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.7"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/test-ajs/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/test-ajs/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "test-ajs"
+      },
+      "versions": [
+        "0.1.19"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.19"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/test-weavedb-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/test-weavedb-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "test-weavedb-sdk"
+      },
+      "versions": [
+        "1.1.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "1.1.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/testnpmnmp/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/testnpmnmp/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "testnpmnmp"
+      },
+      "versions": [
+        "1.0.21"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "1.0.21"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/wao/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/wao/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,43 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "wao"
+      },
+      "versions": [
+        "0.41.2",
+        "0.41.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.41.2",
+          "0.41.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/warp-contracts-plugin-deploy-test/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/warp-contracts-plugin-deploy-test/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "warp-contracts-plugin-deploy-test"
+      },
+      "versions": [
+        "3.0.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "3.0.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/wdb-cli/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/wdb-cli/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "wdb-cli"
+      },
+      "versions": [
+        "0.1.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/wdb-core/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/wdb-core/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "wdb-core"
+      },
+      "versions": [
+        "0.1.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/wdb-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/wdb-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "wdb-sdk"
+      },
+      "versions": [
+        "0.1.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-base/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-base/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-base"
+      },
+      "versions": [
+        "0.45.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-client/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-client/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-client"
+      },
+      "versions": [
+        "0.45.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-console/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-console/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-console"
+      },
+      "versions": [
+        "0.2.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.2.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-contracts/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-contracts/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-contracts"
+      },
+      "versions": [
+        "0.45.2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.2"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-exm-sdk-web/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-exm-sdk-web/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-exm-sdk-web"
+      },
+      "versions": [
+        "0.7.4"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.7.4"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-exm-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-exm-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-exm-sdk"
+      },
+      "versions": [
+        "0.7.4"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.7.4"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-lite/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-lite/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-lite"
+      },
+      "versions": [
+        "0.1.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.1.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-node-client/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-node-client/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-node-client"
+      },
+      "versions": [
+        "0.45.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-offchain/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-offchain/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-offchain"
+      },
+      "versions": [
+        "0.45.4"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.4"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-sdk-base/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-sdk-base/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-sdk-base"
+      },
+      "versions": [
+        "0.21.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.21.1"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-sdk-node/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-sdk-node/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-sdk-node"
+      },
+      "versions": [
+        "0.45.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-sdk/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-sdk"
+      },
+      "versions": [
+        "0.45.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-tools/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-tools/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-tools"
+      },
+      "versions": [
+        "0.45.3"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.45.3"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/weavedb-warp-contracts-plugin-deploy/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/weavedb-warp-contracts-plugin-deploy/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "weavedb-warp-contracts-plugin-deploy"
+      },
+      "versions": [
+        "1.0.11"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "1.0.11"
+        ]
+      }
+    ]
+  }
+}

--- a/osv/malicious/npm/zkjson/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
+++ b/osv/malicious/npm/zkjson/MAL-0000-google-open-source-security-146faaf0d97c6a53.json
@@ -1,0 +1,41 @@
+{
+  "modified": "2026-06-04T22:28:51Z",
+  "published": "2026-06-04T22:27:40Z",
+  "schema_version": "1.7.4",
+  "id": "",
+  "details": "This package was compromised as part of the IronWorm campaign. This campaign executes a malicious binary payload during installation via a preinstall hook. The payload is a Rust-built infostealer that targets developer environments, scanning for and harvesting credentials related to cloud providers, object storage, databases, source-control, package registries, and AI developer tools. It also targets cryptocurrency wallets, specifically injecting a malicious JavaScript hook into the Exodus desktop wallet to capture passwords and recovery phrases. Furthermore, the malware exhibits worm-like behavior by stealing GitHub and NPM credentials to push malicious updates to the victim's repositories and publish trojanized packages, and it uses an eBPF-based kernel rootkit to hide its processes and network connections on Linux systems.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "zkjson"
+      },
+      "versions": [
+        "0.8.5"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ARTICLE",
+      "url": "http://www.ox.security/blog/ironworm-supply-chain-malware-hits-npm/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://research.jfrog.com/post/iron-worm-shai-hulud-rustier-cousin/"
+    }
+  ],
+  "database_specific": {
+    "malicious-packages-origins": [
+      {
+        "source": "google-open-source-security",
+        "sha256": "146faaf0d97c6a533a969bc3f3f117811f9317dc865ed4ab37f1679842ddeaae",
+        "import_time": "2026-06-04T22:42:01.227855Z",
+        "modified_time": "2026-06-04T22:28:51.769005667Z",
+        "versions": [
+          "0.8.5"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Amazon Inspector had most of these already. This change adds arjson, hbsig, wdb-core packages as well.

This change also adds jFrog and OX.security links, as well as refers to them by the "IronWorm" name.