### PR TITLE
Withdraw MAL-2026-1035 neural-compressor-jax false positive

### DIFF
--- a/osv/withdrawn/pypi/neural-compressor-jax/MAL-2026-1035.json
+++ b/osv/withdrawn/pypi/neural-compressor-jax/MAL-2026-1035.json
@@ -1,10 +1,11 @@
 {
-  "modified": "2026-02-25T19:42:30Z",
+  "modified": "2026-06-17T00:00:00Z",
   "published": "2026-02-25T19:42:30Z",
+  "withdrawn": "2026-06-17T00:00:00Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-1035",
   "summary": "Malicious code in neural-compressor-jax (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: kam193 (bb1f58a45ef1a06954d1807517faea8790a771906e95a98d571587558244ea3f)\nInstalling the package or importing the module exfiltrates basic information about the host, and the package has no other purpose.\n\n\n---\n\nCategory: PROBABLY_PENTEST - Packages looking like typical pentest packages, but also anything that looks like testing, exploring pre-prepared kits, research \u0026 co, with clearly low-harm possibilities.\n\n\nCampaign: GENERIC-standard-pypi-install-pentest\n\n\nReasons (based on the campaign):\n\n\n - The package contains code to exfiltrate basic data from the system, like IP or username. It has a limited risk.\n\n\n - The package overrides the install command in setup.py to execute malicious code during installation.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: kam193 (bb1f58a45ef1a06954d1807517faea8790a771906e95a98d571587558244ea3f)\nInstalling the package or importing the module exfiltrates basic information about the host, and the package has no other purpose.\n\n\n---\n\nCategory: PROBABLY_PENTEST - Packages looking like typical pentest packages, but also anything that looks like testing, exploring pre-prepared kits, research & co, with clearly low-harm possibilities.\n\n\nCampaign: GENERIC-standard-pypi-install-pentest\n\n\nReasons (based on the campaign):\n\n\n - The package contains code to exfiltrate basic data from the system, like IP or username. It has a limited risk.\n\n\n - The package overrides the install command in setup.py to execute malicious code during installation.\n",
   "affected": [
     {
       "package": {
@@ -21,6 +22,14 @@
     {
       "type": "WEB",
       "url": "https://bad-packages.kam193.eu/pypi/package/neural-compressor-jax"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pypi/support/issues/10012"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/intel/neural-compressor"
     }
   ],
   "credits": [


### PR DESCRIPTION
### Summery:
The squatted versions (0.0.0, 1.0.0) that triggered this report have been removed from PyPI.

The name is a legitimate continuation of Intel's `neural-compressor` package family maintained at
https://github.com/intel/neural-compressor, which already publishes `neural-compressor`, `neural-compressor-pt`, and `neural-compressor-tf` to PyPI.
The original report was categorized `PROBABLY_PENTEST` (low-harm), not a targeted supply-chain attack. Retaining the prohibition blocks Intel a legitimate publisher with an established PyPI presence.

This is closed in favor of a more comprehensive subsequent PR.