### PR TITLE
Withdraw MAL-2026-1035 neural-compressor-jax (false positive — legitimate Intel package)

### DIFF
--- a/osv/withdrawn/pypi/neural-compressor-jax/MAL-2026-1035.json
+++ b/osv/withdrawn/pypi/neural-compressor-jax/MAL-2026-1035.json
@@ -1,10 +1,11 @@
 {
-  "modified": "2026-02-25T19:42:30Z",
+  "modified": "2026-06-17T00:00:00Z",
   "published": "2026-02-25T19:42:30Z",
+  "withdrawn": "2026-06-17T00:00:00Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-1035",
   "summary": "Malicious code in neural-compressor-jax (PyPI)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: kam193 (bb1f58a45ef1a06954d1807517faea8790a771906e95a98d571587558244ea3f)\nInstalling the package or importing the module exfiltrates basic information about the host, and the package has no other purpose.\n\n\n---\n\nCategory: PROBABLY_PENTEST - Packages looking like typical pentest packages, but also anything that looks like testing, exploring pre-prepared kits, research \u0026 co, with clearly low-harm possibilities.\n\n\nCampaign: GENERIC-standard-pypi-install-pentest\n\n\nReasons (based on the campaign):\n\n\n - The package contains code to exfiltrate basic data from the system, like IP or username. It has a limited risk.\n\n\n - The package overrides the install command in setup.py to execute malicious code during installation.\n",
+  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: kam193 (bb1f58a45ef1a06954d1807517faea8790a771906e95a98d571587558244ea3f)\nInstalling the package or importing the module exfiltrates basic information about the host, and the package has no other purpose.\n\n\n---\n\nCategory: PROBABLY_PENTEST - Packages looking like typical pentest packages, but also anything that looks like testing, exploring pre-prepared kits, research & co, with clearly low-harm possibilities.\n\n\nCampaign: GENERIC-standard-pypi-install-pentest\n\n\nReasons (based on the campaign):\n\n\n - The package contains code to exfiltrate basic data from the system, like IP or username. It has a limited risk.\n\n\n - The package overrides the install command in setup.py to execute malicious code during installation.\n",
   "affected": [
     {
       "package": {
@@ -21,6 +22,14 @@
     {
       "type": "WEB",
       "url": "https://bad-packages.kam193.eu/pypi/package/neural-compressor-jax"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/pypi/support/issues/10012"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/intel/neural-compressor"
     }
   ],
   "credits": [


### PR DESCRIPTION
## Summary

This PR withdraws `MAL-2026-1035` and moves it from `osv/malicious/pypi/` to `osv/withdrawn/pypi/`, removing `neural-compressor-jax` from the PyPI name blocklist.

## Background

In February 2026, security researcher [@kam193](https://github.com/kam193) flagged two versions (`0.0.0`, `1.0.0`) of `neural-compressor-jax` on PyPI. Those versions were squatted under the name and contained code that exfiltrated basic host information (IP address, username) during installation by overriding `setup.py`'s install command. The report was correctly filed at the time.

Importantly, the report itself categorized the finding as **`PROBABLY_PENTEST`** — *"clearly low-harm possibilities"* — not a targeted supply-chain attack or credential-stealing malware. The malicious versions have since been removed from PyPI.

## Why this is a false positive for the name going forward

The name `neural-compressor-jax` belongs to a well-established open-source project maintained by **Intel** at [github.com/intel/neural-compressor](https://github.com/intel/neural-compressor). Intel already publishes an active family of packages under this namespace on PyPI:

- [`neural-compressor`](https://pypi.org/project/neural-compressor/)
- [`neural-compressor-pt`](https://pypi.org/project/neural-compressor-pt/) (PyTorch backend)
- [`neural-compressor-tf`](https://pypi.org/project/neural-compressor-tf/) (TensorFlow backend)

`neural-compressor-jax` is the natural next member of this series (JAX backend). The squatter's use of this name was opportunistic name-squatting, not the legitimate owner publishing under their own namespace.

Intel's team has been blocked from registering the name since the prohibition was put in place and has filed a support request with PyPI: [pypi/support#10012](https://github.com/pypi/support/issues/10012). As of 2026-06-09, PyPI support confirmed the name is prohibited and is evaluating whether it can be released. This withdrawal provides the direct resolution.

## Changes

- Moved `osv/malicious/pypi/neural-compressor-jax/MAL-2026-1035.json` → `osv/withdrawn/pypi/neural-compressor-jax/MAL-2026-1035.json`
- Added `"withdrawn": "2026-06-17T00:00:00Z"` field
- Updated `"modified"` timestamp
- Added references to [pypi/support#10012](https://github.com/pypi/support/issues/10012) and the upstream Intel source repository for traceability

## References

- Original report source: https://bad-packages.kam193.eu/pypi/package/neural-compressor-jax
- Intel neural-compressor repository: https://github.com/intel/neural-compressor
- PyPI unblock request: https://github.com/pypi/support/issues/10012