### PR TITLE
Add OSV reports for Feishu/Lark env-exfil postinstall malware - npm campaign (4 packages)

### DIFF
--- a/osv/malicious/npm/@digitalcnzz/commonmodule/MAL-0000-commonmodule.json
+++ b/osv/malicious/npm/@digitalcnzz/commonmodule/MAL-0000-commonmodule.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-29T00:00:00Z",
+  "published": "2026-06-29T00:00:00Z",
+  "details": "This npm package is purpose-built malware that exfiltrates host information and environment secrets. It runs as a postinstall hook (the keyword \"postinstall\" is obfuscated in the code) and bails immediately if npm_package_name is unset, confirming it only fires during npm install. After a randomized 15-45 second delay it collects host info (hostname, username, platform, Node version, non-internal IPs, and the registry URL) and dumps the entire process.env -- which in CI and developer environments routinely contains tokens, AWS keys, and other secrets -- then POSTs it all to an attacker-controlled endpoint. The C2 destination is obfuscated two ways: the host decoder (reverse + subtract 7) yields open.feishu.cn, and the payload is formatted as a Feishu/Lark bot webhook message (msg_type: \"text\"), so stolen data lands in an attacker's Lark chat. The exfiltration path is XOR-decoded with the key \"Zk9x\". The bulk of the code is anti-analysis: it silently calls process.exit(0) if it detects honeypot canary tokens (AKIAIOSFODNN7EXAMPLE and the matching AWS example secret, fake-token regexes like F4k3T0k3n, \"honey\"), researcher/sandbox env vars and prefixes (DetonationLogFilePath, PYPI_POISON_HONEY_TOKEN, THREAT_ANALYZER_MODEL, ASPECT_TLOG, and prefix scans for SANDYCLAW_, OPENCLAW_, PERMISO_, CHAINRADAR_), a resolved-registry string containing \"supplysec\", NODE_OPTIONS with a --require hook, mock CA paths under /tmp/mock, the NODE_TLS_REJECT_UNAUTHORIZED/profiling combo, 3 or more CI providers set at once (GitHub Actions, GitLab, CircleCI, Buildkite), sandbox hostnames (detonat|cuckoo|virus|scan|chainradar), sandbox usernames (sandbox, malware, scan, etc.), or a HOME path containing \"openclaw\". The char-code/XOR/reverse encoding and the \"Build Environment Telemetry\" comments exist purely to hide the env-var names, the C2 host, and the path from casual review and log scanners.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@digitalcnzz/commonmodule"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            { "introduced": "0" }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["open.feishu.cn"]
+        }
+      }
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/@digitalcnzz/embedded-sdk/MAL-0000-embedded-sdk.json
+++ b/osv/malicious/npm/@digitalcnzz/embedded-sdk/MAL-0000-embedded-sdk.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-29T00:00:00Z",
+  "published": "2026-06-29T00:00:00Z",
+  "details": "This npm package is purpose-built malware that exfiltrates host information and environment secrets. It runs as a postinstall hook (the keyword \"postinstall\" is obfuscated in the code) and bails immediately if npm_package_name is unset, confirming it only fires during npm install. After a randomized 15-45 second delay it collects host info (hostname, username, platform, Node version, non-internal IPs, and the registry URL) and dumps the entire process.env -- which in CI and developer environments routinely contains tokens, AWS keys, and other secrets -- then POSTs it all to an attacker-controlled endpoint. The C2 destination is obfuscated two ways: the host decoder (reverse + subtract 7) yields open.feishu.cn, and the payload is formatted as a Feishu/Lark bot webhook message (msg_type: \"text\"), so stolen data lands in an attacker's Lark chat. The exfiltration path is XOR-decoded with the key \"Zk9x\". The bulk of the code is anti-analysis: it silently calls process.exit(0) if it detects honeypot canary tokens (AKIAIOSFODNN7EXAMPLE and the matching AWS example secret, fake-token regexes like F4k3T0k3n, \"honey\"), researcher/sandbox env vars and prefixes (DetonationLogFilePath, PYPI_POISON_HONEY_TOKEN, THREAT_ANALYZER_MODEL, ASPECT_TLOG, and prefix scans for SANDYCLAW_, OPENCLAW_, PERMISO_, CHAINRADAR_), a resolved-registry string containing \"supplysec\", NODE_OPTIONS with a --require hook, mock CA paths under /tmp/mock, the NODE_TLS_REJECT_UNAUTHORIZED/profiling combo, 3 or more CI providers set at once (GitHub Actions, GitLab, CircleCI, Buildkite), sandbox hostnames (detonat|cuckoo|virus|scan|chainradar), sandbox usernames (sandbox, malware, scan, etc.), or a HOME path containing \"openclaw\". The char-code/XOR/reverse encoding and the \"Build Environment Telemetry\" comments exist purely to hide the env-var names, the C2 host, and the path from casual review and log scanners.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@digitalcnzz/embedded-sdk"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            { "introduced": "0" }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["open.feishu.cn"]
+        }
+      }
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/@longzy/react-native-polyfill/MAL-0000-react-native-polyfill.json
+++ b/osv/malicious/npm/@longzy/react-native-polyfill/MAL-0000-react-native-polyfill.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-29T00:00:00Z",
+  "published": "2026-06-29T00:00:00Z",
+  "details": "This npm package is purpose-built malware that exfiltrates host information and environment secrets. It runs as a postinstall hook (the keyword \"postinstall\" is obfuscated in the code) and bails immediately if npm_package_name is unset, confirming it only fires during npm install. After a randomized 15-45 second delay it collects host info (hostname, username, platform, Node version, non-internal IPs, and the registry URL) and dumps the entire process.env -- which in CI and developer environments routinely contains tokens, AWS keys, and other secrets -- then POSTs it all to an attacker-controlled endpoint. The C2 destination is obfuscated two ways: the host decoder (reverse + subtract 7) yields open.feishu.cn, and the payload is formatted as a Feishu/Lark bot webhook message (msg_type: \"text\"), so stolen data lands in an attacker's Lark chat. The exfiltration path is XOR-decoded with the key \"Zk9x\". The bulk of the code is anti-analysis: it silently calls process.exit(0) if it detects honeypot canary tokens (AKIAIOSFODNN7EXAMPLE and the matching AWS example secret, fake-token regexes like F4k3T0k3n, \"honey\"), researcher/sandbox env vars and prefixes (DetonationLogFilePath, PYPI_POISON_HONEY_TOKEN, THREAT_ANALYZER_MODEL, ASPECT_TLOG, and prefix scans for SANDYCLAW_, OPENCLAW_, PERMISO_, CHAINRADAR_), a resolved-registry string containing \"supplysec\", NODE_OPTIONS with a --require hook, mock CA paths under /tmp/mock, the NODE_TLS_REJECT_UNAUTHORIZED/profiling combo, 3 or more CI providers set at once (GitHub Actions, GitLab, CircleCI, Buildkite), sandbox hostnames (detonat|cuckoo|virus|scan|chainradar), sandbox usernames (sandbox, malware, scan, etc.), or a HOME path containing \"openclaw\". The char-code/XOR/reverse encoding and the \"Build Environment Telemetry\" comments exist purely to hide the env-var names, the C2 host, and the path from casual review and log scanners.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@longzy/react-native-polyfill"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            { "introduced": "0" }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["open.feishu.cn"]
+        }
+      }
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/@sailing-package/core/MAL-0000-core.json
+++ b/osv/malicious/npm/@sailing-package/core/MAL-0000-core.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-29T00:00:00Z",
+  "published": "2026-06-29T00:00:00Z",
+  "details": "This npm package is purpose-built malware that exfiltrates host information and environment secrets. It runs as a postinstall hook (the keyword \"postinstall\" is obfuscated in the code) and bails immediately if npm_package_name is unset, confirming it only fires during npm install. After a randomized 15-45 second delay it collects host info (hostname, username, platform, Node version, non-internal IPs, and the registry URL) and dumps the entire process.env -- which in CI and developer environments routinely contains tokens, AWS keys, and other secrets -- then POSTs it all to an attacker-controlled endpoint. The C2 destination is obfuscated two ways: the host decoder (reverse + subtract 7) yields open.feishu.cn, and the payload is formatted as a Feishu/Lark bot webhook message (msg_type: \"text\"), so stolen data lands in an attacker's Lark chat. The exfiltration path is XOR-decoded with the key \"Zk9x\". The bulk of the code is anti-analysis: it silently calls process.exit(0) if it detects honeypot canary tokens (AKIAIOSFODNN7EXAMPLE and the matching AWS example secret, fake-token regexes like F4k3T0k3n, \"honey\"), researcher/sandbox env vars and prefixes (DetonationLogFilePath, PYPI_POISON_HONEY_TOKEN, THREAT_ANALYZER_MODEL, ASPECT_TLOG, and prefix scans for SANDYCLAW_, OPENCLAW_, PERMISO_, CHAINRADAR_), a resolved-registry string containing \"supplysec\", NODE_OPTIONS with a --require hook, mock CA paths under /tmp/mock, the NODE_TLS_REJECT_UNAUTHORIZED/profiling combo, 3 or more CI providers set at once (GitHub Actions, GitLab, CircleCI, Buildkite), sandbox hostnames (detonat|cuckoo|virus|scan|chainradar), sandbox usernames (sandbox, malware, scan, etc.), or a HOME path containing \"openclaw\". The char-code/XOR/reverse encoding and the \"Build Environment Telemetry\" comments exist purely to hide the env-var names, the C2 host, and the path from casual review and log scanners.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@sailing-package/core"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            { "introduced": "0" }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["open.feishu.cn"]
+        }
+      }
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Four npm packages that are purpose-built malware sharing a single payload. The payload runs as an obfuscated `postinstall` hook (it bails immediately if `npm_package_name` is unset, so it only fires during `npm install`). After a randomized 15–45s delay it collects host info (hostname, username, platform, Node version, non-internal IPs, registry URL) and dumps the entire `process.env` — which in CI/dev environments routinely holds tokens, AWS keys, and other secrets — then exfiltrates it.

The C2 destination is obfuscated two ways: the host decoder (reverse + subtract 7) yields `open.feishu.cn`, and the payload is formatted as a Feishu/Lark bot webhook message (`msg_type: "text"`), so stolen data lands in an attacker's Lark chat. The exfil path is XOR-decoded with the key `Zk9x`.

The bulk of the code is anti-analysis: it silently `process.exit(0)`s on honeypot canary tokens (`AKIAIOSFODNN7EXAMPLE` and the matching AWS example secret, fake-token regexes, `honey`), researcher/sandbox env markers (`DetonationLogFilePath`, `PYPI_POISON_HONEY_TOKEN`, `THREAT_ANALYZER_MODEL`, `ASPECT_TLOG`, and prefix scans for `SANDYCLAW_`, `OPENCLAW_`, `PERMISO_`, `CHAINRADAR_`), a resolved-registry string containing `supplysec`, `NODE_OPTIONS` `--require` hooks, mock CA paths under `/tmp/mock`, the `NODE_TLS_REJECT_UNAUTHORIZED`/profiling combo, 3+ CI providers set at once, and sandbox hostnames/usernames. The "Build Environment Telemetry" comments and char-code/XOR/reverse encoding exist purely to hide the env-var names, C2 host, and path from review and log scanners.

**IOC:** `open.feishu.cn` (Feishu/Lark webhook exfil endpoint)

## Packages

- `@longzy/react-native-polyfill` (npm)
- `@sailing-package/core` (npm)
- `@digitalcnzz/commonmodule` (npm)
- `@digitalcnzz/embedded-sdk` (npm)
