### PR TITLE
Add OSV report for ulid-xyz (npm typosquat RAT)

### DIFF
--- a/osv/malicious/npm/ulid-xyz/MAL-0000-ulid-xyz.json
+++ b/osv/malicious/npm/ulid-xyz/MAL-0000-ulid-xyz.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-29T00:00:00Z",
+  "published": "2026-06-29T00:00:00Z",
+  "details": "ulid-xyz is a typosquat of the popular ulid library (sortable unique IDs) and is a cross-platform Remote Access Trojan delivered via a postinstall hook. The package.json postinstall superficially looks like an inline `node -e` guard that checks for the existence of a dist file, but it actually launches dist/node/utils.js as a detached background process, which in turn runs dist/node/payload.js -- a 467 KB bundled RAT. payload.js decodes XOR+base64-obfuscated configuration (_CFG.WS / _CFG.HTTP) to beacon to a hardcoded attacker-controlled C2 over WebSocket at ws://95.216.232.162:8010/ (with an HTTP fallback at http://95.216.232.162:8010/), establishing a WebSocket RAT channel. It installs persistence on all three major operating systems under the stem MicrosoftSystem64: on Windows under %LOCALAPPDATA%\\MicrosoftSystem64; on macOS under ~/Library/Application Support/MicrosoftSystem64 plus a LaunchAgent at ~/Library/LaunchAgents/com.launchkeeper.MicrosoftSystem64.plist; and on Linux under ~/.local/share/MicrosoftSystem64. The install-time detached spawn (process management capability) and the ~8x package size spike (64 KB to 536 KB) correspond to the bundled RAT payload -- behavior a ULID library has no legitimate need for. All versions of ulid-xyz were published by the same actor (iloiyxo643 / iloiyxo643@ufiwi.space, a disposable email address) and are considered malicious.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ulid-xyz"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            { "introduced": "0" }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "ips": ["95.216.232.162"],
+          "urls": [
+            "ws://95.216.232.162:8010/",
+            "http://95.216.232.162:8010/"
+          ]
+        }
+      }
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}


### PR DESCRIPTION
Adds an OSV report for `ulid-xyz` (npm), a typosquat of `ulid`.

A `postinstall` hook detaches a launcher that runs a 467 KB bundled RAT (`dist/node/payload.js`), which beacons over WebSocket to a hardcoded C2 (`ws://95.216.232.162:8010/`) and installs cross-OS persistence under the stem `MicrosoftSystem64`. All versions are published by a single disposable-email actor and are marked malicious.