### PR TITLE
Add OSV reports for DeFi infostealer fake arbitrage bot - npm campaign (8 packages)

### DIFF
--- a/osv/malicious/npm/console-fmt-cli/MAL-0000-console-fmt-cli.json
+++ b/osv/malicious/npm/console-fmt-cli/MAL-0000-console-fmt-cli.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign. `console-fmt-cli` uses a side-loader technique: it declares `decimal-format-core >=3.0` as a dependency, which contains a dropper that executes at install time via a `postinstall` hook. The dropper fetches a second-stage infostealer from a remote C2 (`logstream-api.online`) that harvests cryptocurrency wallet vaults (MetaMask, Phantom, Solflare, OKX, Coinbase, TrustWallet, Backpack, TronLink), browser cookies and credentials, SSH keys, AWS credentials, `.npmrc` tokens, Docker config, shell history, and password manager databases.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "console-fmt-cli"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["logstream-api.online"]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/decimal-format-core/MAL-0000-decimal-format-core.json
+++ b/osv/malicious/npm/decimal-format-core/MAL-0000-decimal-format-core.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign. `decimal-format-core` uses a dropper technique: a `postinstall` hook executes `scripts/install-check.cjs` at install time, which fetches a second-stage infostealer payload from the C2 domain `logstream-api.online`. The infostealer harvests cryptocurrency wallet vaults (MetaMask, Phantom, Solflare, OKX, Coinbase, TrustWallet, Backpack, TronLink), Chrome/Firefox/Brave cookies and credentials, SSH keys, AWS credentials, `.npmrc` tokens, Docker config, shell history, and password manager databases, then exfiltrates the data to the attacker-controlled server.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "decimal-format-core"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["logstream-api.online"]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/log-taker1/MAL-0000-log-taker1.json
+++ b/osv/malicious/npm/log-taker1/MAL-0000-log-taker1.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign. `log-taker1` embeds a full infostealer (~2800 lines) directly in `index.js`, executed at install time via `postinstall: node test.js`. The payload harvests cryptocurrency wallet vaults (MetaMask, Phantom, Solflare, OKX, Coinbase, TrustWallet, Backpack, TronLink), browser cookies and credentials, SSH keys, AWS credentials, `.npmrc` tokens, Docker config, shell history, and password manager databases, exfiltrating all data to the C2 domain `log-taker.store`. The C2 is shared with the `rohmat2527` maintainer account.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "log-taker1"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["log-taker.store"]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/polymarket-clob-maths/MAL-0000-polymarket-clob-maths.json
+++ b/osv/malicious/npm/polymarket-clob-maths/MAL-0000-polymarket-clob-maths.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign targeting Polymarket developers. `polymarket-clob-maths` uses a dropper technique: a `postinstall` hook fetches a remote bundle from `trabalhos-flax.vercel.app` and executes a `syncSession()` function that runs a second-stage infostealer. The payload harvests cryptocurrency wallet vaults, browser credentials, SSH keys, AWS credentials, developer secrets, and password manager databases, then exfiltrates the data to the attacker-controlled C2.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "polymarket-clob-maths"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["trabalhos-flax.vercel.app"]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/polymarket-trading-developer-tools/MAL-0000-polymarket-trading-developer-tools.json
+++ b/osv/malicious/npm/polymarket-trading-developer-tools/MAL-0000-polymarket-trading-developer-tools.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign targeting Polymarket developers. `polymarket-trading-developer-tools` uses a dropper technique: a `postinstall` hook downloads configuration from `pm-trading-dev-tools-be.vercel.app` and exfiltrates data to the shared C2 `polymarket-clob-service.vercel.app`. The payload harvests cryptocurrency wallet vaults, browser credentials, SSH keys, AWS credentials, developer secrets, shell history, and password manager databases.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "polymarket-trading-developer-tools"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": [
+            "polymarket-clob-service.vercel.app",
+            "pm-trading-dev-tools-be.vercel.app"
+          ]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/thirdwb/MAL-0000-thirdwb.json
+++ b/osv/malicious/npm/thirdwb/MAL-0000-thirdwb.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign. `thirdwb` is a typosquat of the legitimate `thirdweb` package. It uses a side-loader technique, pulling in `log-taker` as a transitive dependency; the infostealer runs automatically via that dependency's `postinstall` hook. The payload harvests cryptocurrency wallet vaults (MetaMask, Phantom, Solflare, OKX, Coinbase, TrustWallet, Backpack, TronLink), browser cookies and credentials, SSH keys, AWS credentials, `.npmrc` tokens, Docker config, shell history, and password manager databases, exfiltrating all data to the C2 domain `log-taker.store`.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "thirdwb"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["log-taker.store"]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/thirdwebb/MAL-0000-thirdwebb.json
+++ b/osv/malicious/npm/thirdwebb/MAL-0000-thirdwebb.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign. `thirdwebb` is a typosquat of the legitimate `thirdweb` package. It uses a side-loader technique, pulling in `log-taker` as a transitive dependency; the infostealer runs automatically via that dependency's `postinstall` hook. The payload harvests cryptocurrency wallet vaults (MetaMask, Phantom, Solflare, OKX, Coinbase, TrustWallet, Backpack, TronLink), browser cookies and credentials, SSH keys, AWS credentials, `.npmrc` tokens, Docker config, shell history, and password manager databases, exfiltrating all data to the C2 domain `log-taker.store`.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "thirdwebb"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["log-taker.store"]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}

--- a/osv/malicious/npm/ts-bn-proto/MAL-0000-ts-bn-proto.json
+++ b/osv/malicious/npm/ts-bn-proto/MAL-0000-ts-bn-proto.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-06-30T00:00:00Z",
+  "published": "2026-06-30T00:00:00Z",
+  "details": "Malicious npm package published as part of a coordinated DeFi-themed infostealer campaign. `ts-bn-proto` embeds an infostealer payload directly in `index.js` with a base64-encoded C2 address (`data-stream.space`), executed at install time via a `postinstall` hook. The payload harvests cryptocurrency wallet vaults (MetaMask, Phantom, Solflare, OKX, Coinbase, TrustWallet, Backpack, TronLink), browser cookies and credentials, SSH keys, AWS credentials, developer secrets, and password manager databases, then exfiltrates all data to the attacker-controlled C2.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "ts-bn-proto"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [{ "introduced": "0" }]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "domains": ["data-stream.space"]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

OSV reports for 8 npm packages from the coordinated DeFi-themed infostealer campaign documented at https://safedep.io/defi-infostealer-fake-arbitrage-bot-npm/

- `console-fmt-cli` — side-loader via `decimal-format-core` dependency
- `decimal-format-core` — dropper via `postinstall`, C2: `logstream-api.online`
- `log-taker1` — direct embed infostealer (~2800 lines), C2: `log-taker.store`
- `polymarket-clob-maths` — dropper via `postinstall`, C2: `trabalhos-flax.vercel.app`
- `polymarket-trading-developer-tools` — dropper via `postinstall`, C2: `polymarket-clob-service.vercel.app`
- `thirdwb` — typosquat of `thirdweb`, side-loader via `log-taker`, C2: `log-taker.store`
- `thirdwebb` — typosquat of `thirdweb`, side-loader via `log-taker`, C2: `log-taker.store`
- `ts-bn-proto` — direct embed with base64-encoded C2: `data-stream.space`

All packages: npm, all versions malicious (`introduced: "0"`), CWE-506.