### PR TITLE
Malicious package: npm/datefmt-helper (download-and-execute dropper)

### DIFF
--- a/osv/malicious/npm/datefmt-helper/MAL-0000-datefmt-helper.json
+++ b/osv/malicious/npm/datefmt-helper/MAL-0000-datefmt-helper.json
@@ -1,42 +1,43 @@
 {
-    "modified": "2026-07-04T00:00:00Z",
-    "published": "2026-07-04T00:00:00Z",
-    "schema_version": "1.6.0",
-    "affected": [
-      {
-        "package": {
-          "ecosystem": "npm",
-          "name": "datefmt-helper"
-        },
-        "versions": [
-          "1.0.0",
-          "1.0.1"
-        ]
-      }
-    ],
-    "details": "The npm package `datefmt-helper` is a supply-chain dropper disguised as a benign date-formatting utility (its `description` reads \"dates formatting utility with locale support\"). The package ships no source 
-  script uses HTTP / `curl` / `wget` primitives to download a second-stage payload from the hardcoded external IP `115.190.124.243`, then executes it via a Node child process — the classic download-and-execute pattern. Any 
-  developer workstation or CI runner that installs the package (directly or transitively) hands arbitrary code execution to the operator of that endpoint.\n\nDetected and classified independently by codelake Research from the 
-  live npm feed on 2026-07-02; at the time of reporting the package was not present in OSV or GHSA (a first-catch).",
-    "credits": [
-      {
-        "name": "codelake Research",
-        "type": "FINDER",
-        "contact": [
-          "https://research.codelake.dev/advisories/clr-2026-2990-datefmt-helper"
-        ] 
-      } 
-    ],
-    "references": [
-      {
-        "type": "ADVISORY",
-        "url": "https://research.codelake.dev/advisories/clr-2026-2990-datefmt-helper"
-      } 
-    ],
-    "database_specific": {
-      "iocs": [
-        "115.190.124.243",
+  "modified": "2026-07-04T00:00:00Z",
+  "published": "2026-07-04T00:00:00Z",
+  "schema_version": "1.6.0",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "datefmt-helper"
+      },
+      "versions": [
+        "1.0.0",
+        "1.0.1"
+      ]
+    }
+  ],
+  "details": "The npm package `datefmt-helper` is a supply-chain dropper disguised as a benign date-formatting utility (its `description` reads \"dates formatting utility with locale support\"). The package ships no source repository and places its real behaviour in an install script.\n\nA `postinstall` lifecycle hook (`postinstall: node postinstall.js`) executes automatically on `npm install`, before the package is ever imported. The install script uses HTTP / `curl` / `wget` primitives to download a second-stage payload from the hardcoded external IP `115.190.124.243`, then executes it via a Node child process — the classic download-and-execute pattern. Any developer workstation or CI runner that installs the package (directly or transitively) hands arbitrary code execution to the operator of that endpoint.\n\nDetected and classified independently by codelake Research from the live npm feed on 2026-07-02; at the time of reporting the package was not present in OSV or GHSA (a first-catch).",
+  "credits": [
+    {
+      "name": "codelake Research",
+      "type": "FINDER",
+      "contact": [
+        "https://research.codelake.dev/advisories/clr-2026-2990-datefmt-helper"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://research.codelake.dev/advisories/clr-2026-2990-datefmt-helper"
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "ips": [
+        "115.190.124.243"
+      ],
+      "hashes": [
         "sha256:f2f58e73becce20f28c6f18700731f48c067826defe8279da2e24e4f69c25c72"
       ]
     }
-  } 
+  }
+}

--- a/osv/malicious/npm/datefmt-helper/MAL-0000-datefmt-helper.json
+++ b/osv/malicious/npm/datefmt-helper/MAL-0000-datefmt-helper.json
@@ -1,0 +1,42 @@
+{
+    "modified": "2026-07-04T00:00:00Z",
+    "published": "2026-07-04T00:00:00Z",
+    "schema_version": "1.6.0",
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "npm",
+          "name": "datefmt-helper"
+        },
+        "versions": [
+          "1.0.0",
+          "1.0.1"
+        ]
+      }
+    ],
+    "details": "The npm package `datefmt-helper` is a supply-chain dropper disguised as a benign date-formatting utility (its `description` reads \"dates formatting utility with locale support\"). The package ships no source 
+  script uses HTTP / `curl` / `wget` primitives to download a second-stage payload from the hardcoded external IP `115.190.124.243`, then executes it via a Node child process — the classic download-and-execute pattern. Any 
+  developer workstation or CI runner that installs the package (directly or transitively) hands arbitrary code execution to the operator of that endpoint.\n\nDetected and classified independently by codelake Research from the 
+  live npm feed on 2026-07-02; at the time of reporting the package was not present in OSV or GHSA (a first-catch).",
+    "credits": [
+      {
+        "name": "codelake Research",
+        "type": "FINDER",
+        "contact": [
+          "https://research.codelake.dev/advisories/clr-2026-2990-datefmt-helper"
+        ] 
+      } 
+    ],
+    "references": [
+      {
+        "type": "ADVISORY",
+        "url": "https://research.codelake.dev/advisories/clr-2026-2990-datefmt-helper"
+      } 
+    ],
+    "database_specific": {
+      "iocs": [
+        "115.190.124.243",
+        "sha256:f2f58e73becce20f28c6f18700731f48c067826defe8279da2e24e4f69c25c72"
+      ]
+    }
+  } 


### PR DESCRIPTION
Adds an OSV record for the npm package `datefmt-helper`, a download-and-execute
supply-chain dropper disguised as a date-formatting utility.
  
A `postinstall` hook runs `node postinstall.js` on install, which downloads a
second-stage payload from the hardcoded IP 115.190.124.243 and executes it via a
Node child process — arbitrary code execution on any machine or CI runner that 
installs the package (versions 1.0.0, 1.0.1). 
  
Detected by codelake Research from the live npm feed on 2026-07-02; not present in
OSV or GHSA at the time of reporting.
  
IOCs:
- Remote endpoint: 115.190.124.243
- sha256 (datefmt-helper-1.0.0.tgz): f2f58e73becce20f28c6f18700731f48c067826defe8279da2e24e4f69c25c72
  
Full technical write-up: https://research.codelake.dev/advisories/clr-2026-2990-datefmt-helper