### PR TITLE
Malicious package: npm/realagent (curl-to-bash download-execute dropper)

### DIFF
--- a/osv/malicious/npm/realagent/MAL-0000-realagent.json
+++ b/osv/malicious/npm/realagent/MAL-0000-realagent.json
@@ -1,0 +1,45 @@
+{
+  "modified": "2026-07-05T00:00:00Z",
+  "published": "2026-07-05T00:00:00Z",
+  "schema_version": "1.6.0",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "realagent"
+      },
+      "versions": [
+        "1.1.0"
+      ]
+    }
+  ],
+  "details": "The npm package `realagent` is a supply-chain dropper disguised as an \"MCP Server\" (its `description` reads \"RealAgent MCP Server\"). It ships four files (cli.js, install.js, README, package.json) and no dependencies, with its real behaviour in an install script.\n\nA `postinstall` lifecycle hook (`postinstall: node install.js`) executes automatically on `npm install`, before the package is ever imported. The install script uses `curl` to fetch a remote shell script from the hardcoded external endpoint `http://60.247.61.162:8083/install.sh` and executes it via a Node child process, piping the downloaded content to `bash` (execSync) — the classic curl-to-bash download-and-execute pattern. Any developer workstation or CI runner that installs the package (directly or transitively) hands arbitrary code execution to the operator of that endpoint.\n\nDetected and classified independently by codelake Research from the live npm feed; at the time of reporting the package was not present in OSV or GHSA (a first-catch).",
+  "credits": [
+    {
+      "name": "codelake Research",
+      "type": "FINDER",
+      "contact": [
+        "https://research.codelake.dev/advisories/clr-2026-2992-realagent"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://research.codelake.dev/advisories/clr-2026-2992-realagent"
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "ips": [
+        "60.247.61.162"
+      ],
+      "urls": [
+        "http://60.247.61.162:8083/install.sh"
+      ],
+      "hashes": [
+        "sha256:043af19d6aee166ef5cc796eeca42e2508664f9a574ff1c86052850e8a653f49"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds an OSV record for the npm package `realagent`, a download-and-execute supply-chain dropper disguised as an "MCP Server" ("RealAgent MCP Server").

A `postinstall` hook runs `node install.js` on install, which uses `curl` to fetch a remote shell script from the hardcoded endpoint http://60.247.61.162:8083/install.sh and executes it via a Node child process piped to bash (execSync) — arbitrary code execution on any machine or CI runner that installs the package (version 1.1.0).

Detected by codelake Research from the live npm feed; not present in OSV or GHSA at the time of reporting.

IOCs:
- Remote endpoint: http://60.247.61.162:8083/install.sh (and /api/version/latest)
- sha256 (realagent-1.1.0.tgz): 043af19d6aee166ef5cc796eeca42e2508664f9a574ff1c86052850e8a653f49

Full write-up: https://research.codelake.dev/advisories/clr-2026-2992-realagent