### PR TITLE
Add OSV reports for forge-jsx RAT campaign Wave 4 (npm: zredis-typed, pinokio-redis)

### DIFF
--- a/osv/malicious/npm/pinokio-redis/MAL-0000-pinokio-redis.json
+++ b/osv/malicious/npm/pinokio-redis/MAL-0000-pinokio-redis.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-06T00:00:00Z",
+  "published": "2026-07-06T00:00:00Z",
+  "details": "pinokio-redis is a malicious npm package and part of the multi-wave \"forge-jsx\" cross-platform RAT campaign (Wave 4). It was published by npm account 'donimique' (donimiqueakers@gmail.com). The package.json description ('Node.js integration layer for Autodesk Forge') and the bundled README.md (literally titled \"# forge-jsx\") do not match the package name or the shipped code.\n\nOn npm install the declared postinstall chain (postinstall-clipboard-event.mjs, ensure-dist.mjs, postinstall-durable-materialize.mjs, postinstall-bootstrap.mjs, postinstall-agent.mjs) runs scripts/postinstall-agent.mjs, which spawns dist/cli-agent.js as a detached, window-hidden background process. The agent connects over WebSocket to a command-and-control relay whose host, ports and default password are stored as an AES-256-GCM blob in dist/deploymentCipherData.js and decrypted at runtime by XOR-reconstructing a 32-byte key from two halves embedded in dist/deploymentDefaults.js. The decrypted C2 configuration is publicHost 212.193.3.61, relayPort 9877 (WebSocket relay), apiPort 8765 (HTTP API), default password 'secret'. Postinstall also registers OS-level autostart (Windows Run key, macOS LaunchAgent, Linux systemd/XDG autostart; service name forge-js-worker) pointing at a durable copy of the agent stored in a hidden '.forge-jsxy' directory under the platform application-data folder, so the implant survives removal of the npm package.\n\nOnce running it performs credential-grade theft: dist/secretScan/agentStartupAudit.js walks the filesystem for BIP39-checksum-valid mnemonics, secp256k1/WIF private keys and BIP32 extended keys (xprv/tprv/zprv); dist/chromiumExtensionDbHarvest.js enumerates Chromium/Edge/Brave/Vivaldi/Yandex/Opera profiles across Windows, macOS and Linux and copies extension LevelDB stores (including MetaMask/Phantom-shaped wallet stores); harvested data is uploaded to the Hugging Face Hub using an embedded hf_ write token (dist/hfCredentials.js) or delivered via the relay; dist/hostInventorySend.js POSTs host inventory (hostname/platform/node/OS) to the relay and dist/discordRelayUpload.js forwards agent-side PNG screenshots to per-client Discord channels.\n\nThis is the first wave of the campaign to ship rotated AES key material (new DEPLOYMENT_KEY_A/KEY_B/MASK_A/MASK_B byte arrays, hex 12335cede9edad1edbce89fd3ef0836c8edd3778e48f3f38f2330198ec8b1eb0), verified byte-identical across the four donimique-account packages (zod-pino434, zod-pino444, zredis-typed, pinokio-redis) \u2014 a single shared build. C2 212.193.3.61 (AS206216, Advin Services LLC, Nurnberg DE) is reused from the Wave 3 pino-zod/zod-pino IP rotation. The campaign is definitively linked by shared C2 infrastructure, the hardcoded '.forge-jsxy' durable directory, the dist/deploymentCipherData.js + dist/deploymentDefaults.js XOR-key fingerprint, and the '# forge-jsx' README tell that spans multiple package names and npm accounts. Only one version of pinokio-redis (1.0.127) exists and all versions are malicious. Tarball SHA-256: a400b0342add77fd3a58e086334b35e11d79e234b180bb360f48adcd61ec4acd, SHA-1: 04b6035df92ef9eb790d64d425c05c51fce46ca7.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "pinokio-redis"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "ips": [
+            "212.193.3.61"
+          ]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/malicious-forge-jsxy-npm-rat-evolution/"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/pinokio-redis"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ]
+}

--- a/osv/malicious/npm/zredis-typed/MAL-0000-zredis-typed.json
+++ b/osv/malicious/npm/zredis-typed/MAL-0000-zredis-typed.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-06T00:00:00Z",
+  "published": "2026-07-06T00:00:00Z",
+  "details": "zredis-typed is a malicious npm package and part of the multi-wave \"forge-jsx\" cross-platform RAT campaign (Wave 4). It was published by npm account 'donimique' (donimiqueakers@gmail.com). The package.json description ('Node.js integration layer for Autodesk Forge') and the bundled README.md (literally titled \"# forge-jsx\") do not match the package name or the shipped code.\n\nOn npm install the declared postinstall chain (postinstall-clipboard-event.mjs, ensure-dist.mjs, postinstall-durable-materialize.mjs, postinstall-bootstrap.mjs, postinstall-agent.mjs) runs scripts/postinstall-agent.mjs, which spawns dist/cli-agent.js as a detached, window-hidden background process. The agent connects over WebSocket to a command-and-control relay whose host, ports and default password are stored as an AES-256-GCM blob in dist/deploymentCipherData.js and decrypted at runtime by XOR-reconstructing a 32-byte key from two halves embedded in dist/deploymentDefaults.js. The decrypted C2 configuration is publicHost 212.193.3.61, relayPort 9877 (WebSocket relay), apiPort 8765 (HTTP API), default password 'secret'. Postinstall also registers OS-level autostart (Windows Run key, macOS LaunchAgent, Linux systemd/XDG autostart; service name forge-js-worker) pointing at a durable copy of the agent stored in a hidden '.forge-jsxy' directory under the platform application-data folder, so the implant survives removal of the npm package.\n\nOnce running it performs credential-grade theft: dist/secretScan/agentStartupAudit.js walks the filesystem for BIP39-checksum-valid mnemonics, secp256k1/WIF private keys and BIP32 extended keys (xprv/tprv/zprv); dist/chromiumExtensionDbHarvest.js enumerates Chromium/Edge/Brave/Vivaldi/Yandex/Opera profiles across Windows, macOS and Linux and copies extension LevelDB stores (including MetaMask/Phantom-shaped wallet stores); harvested data is uploaded to the Hugging Face Hub using an embedded hf_ write token (dist/hfCredentials.js) or delivered via the relay; dist/hostInventorySend.js POSTs host inventory (hostname/platform/node/OS) to the relay and dist/discordRelayUpload.js forwards agent-side PNG screenshots to per-client Discord channels.\n\nThis is the first wave of the campaign to ship rotated AES key material (new DEPLOYMENT_KEY_A/KEY_B/MASK_A/MASK_B byte arrays, hex 12335cede9edad1edbce89fd3ef0836c8edd3778e48f3f38f2330198ec8b1eb0), verified byte-identical across the four donimique-account packages (zod-pino434, zod-pino444, zredis-typed, pinokio-redis) \u2014 a single shared build. C2 212.193.3.61 (AS206216, Advin Services LLC, Nurnberg DE) is reused from the Wave 3 pino-zod/zod-pino IP rotation. The campaign is definitively linked by shared C2 infrastructure, the hardcoded '.forge-jsxy' durable directory, the dist/deploymentCipherData.js + dist/deploymentDefaults.js XOR-key fingerprint, and the '# forge-jsx' README tell that spans multiple package names and npm accounts. Only one version of zredis-typed (1.0.127) exists; all versions are malicious. Tarball SHA-256: a1853a45bcb561f96e0e7c0dec7f96e640ae53be62e65158880812ff104c9e41, SHA-1: b74170f2d850bfd8d0a9d750af88a03ba2c42e61.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "zredis-typed"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "iocs": {
+          "ips": [
+            "212.193.3.61"
+          ]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://safedep.io/malicious-forge-jsxy-npm-rat-evolution/"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/zredis-typed"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Reports **2 malicious npm packages** — `zredis-typed` v1.0.127 and `pinokio-redis` v1.0.127 — published by npm account `donimique` (`donimiqueakers@gmail.com`). Both are part of the multi-wave **forge-jsx cross-platform RAT** campaign (Wave 4), disguised as Autodesk Forge SDK packages.

The sibling Wave 4 packages `zod-pino434` (MAL-2026-6794) and `zod-pino444` (MAL-2026-6795) are already in OSV via Amazon Inspector, so they are intentionally not duplicated here.

## Behavior

Both packages carry an identical `postinstall` agent chain that runs at install time:

- Spawns `dist/cli-agent.js` as a detached, window-hidden process.
- Connects over WebSocket to C2 **`212.193.3.61`** (relay `:9877`, HTTP API `:8765`, default password `secret`), whose config is an AES-256-GCM blob decrypted at runtime via an XOR-reconstructed key.
- Installs OS-level persistence (Windows Run key / macOS LaunchAgent / Linux systemd + XDG autostart, service `forge-js-worker`) under a hidden `.forge-jsxy` durable directory that **survives npm uninstall**.
- Steals crypto material (BIP39 mnemonics, secp256k1/WIF keys, BIP32 xprv/tprv/zprv), harvests Chromium/Edge/Brave/Vivaldi/Yandex/Opera extension LevelDB stores (MetaMask/Phantom-shaped wallets), and exfiltrates to the Hugging Face Hub (embedded `hf_` token) and Discord channels.

## Campaign linkage

This is the first wave to ship **rotated AES key material** (`DEPLOYMENT_KEY_A/KEY_B/MASK_A/MASK_B`, hex `12335cede9edad1edbce89fd3ef0836c8edd3778e48f3f38f2330198ec8b1eb0`), byte-identical across the four `donimique`-account packages — a single shared build. C2 `212.193.3.61` (AS206216, Advin Services LLC, Nürnberg DE) is reused from the Wave 3 `pino-zod`/`zod-pino` rotation. Durable fingerprints independent of package name: the hardcoded `.forge-jsxy` directory, the `dist/deploymentCipherData.js` + `dist/deploymentDefaults.js` XOR-key routine, and a bundled `README.md` literally titled `# forge-jsx`.

| Package | Version(s) | C2 |
|---|---|---|
| `zredis-typed` | 1.0.127 (only version; all malicious) | 212.193.3.61 |
| `pinokio-redis` | 1.0.127 (only version; all malicious) | 212.193.3.61 |

### IOCs
- C2: `212.193.3.61` (ports 9877, 8765)
- `zredis-typed` v1.0.127 — SHA-256 `a1853a45bcb561f96e0e7c0dec7f96e640ae53be62e65158880812ff104c9e41`
- `pinokio-redis` v1.0.127 — SHA-256 `a400b0342add77fd3a58e086334b35e11d79e234b180bb360f48adcd61ec4acd`

Full campaign analysis: https://safedep.io/malicious-forge-jsxy-npm-rat-evolution/