### PR TITLE
fix: remove open range from mistralai package

### DIFF
--- a/osv/malicious/npm/@mistralai/mistralai/MAL-2026-3432.json
+++ b/osv/malicious/npm/@mistralai/mistralai/MAL-2026-3432.json
@@ -101,16 +101,6 @@
         "import_time": "2026-05-12T01:08:51.454429056Z",
         "id": "GHSA-3q49-cfcf-g5fm",
         "modified_time": "2026-05-12T00:28:13Z",
-        "ranges": [
-          {
-            "type": "SEMVER",
-            "events": [
-              {
-                "introduced": "0"
-              }
-            ]
-          }
-        ],
         "versions": [
           "2.2.4",
           "2.2.3",


### PR DESCRIPTION
this package should not have range introduced 0, only 3 versions were malware. 