### PR TITLE
Add malicious npm package react-next-vite

### DIFF
--- a/osv/malicious/npm/react-next-vite/MAL-0000-react-next-vite.json
+++ b/osv/malicious/npm/react-next-vite/MAL-0000-react-next-vite.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-07T23:38:58Z",
+  "published": "2026-07-07T23:38:58Z",
+  "details": "The npm package react-next-vite version 1.2.9 contains a runtime remote-code-execution payload. The package main entrypoint is index.js. When the exported middleware/factory function is invoked, index.js starts a detached Node child process running lib/caller.js with stdio ignored and the child unrefed. lib/caller.js fetches a remote object from a mypinata.cloud IPFS gateway URL, reads the response data.cookie value as JavaScript, constructs a Function with require access, and executes the fetched code. This gives the remote payload arbitrary code execution in the consuming project environment. The package has no install lifecycle hook, but the malicious behavior is reachable through the package's main runtime API. LPM Firewall independently matched index.js to the known malicious package webpack-patch@1.1.8 with identical source fingerprint evidence.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "react-next-vite",
+        "purl": "pkg:npm/react-next-vite"
+      },
+      "versions": [
+        "1.2.9"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          },
+          {
+            "cweId": "CWE-94",
+            "description": "The product constructs code from externally-controlled input and executes it.",
+            "name": "Improper Control of Generation of Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/react-next-vite/v/1.2.9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://firewall.lpm.dev/npm/react-next-vite/v/1.2.9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://unpkg.com/react-next-vite@1.2.9/index.js"
+    },
+    {
+      "type": "WEB",
+      "url": "https://unpkg.com/react-next-vite@1.2.9/lib/caller.js"
+    }
+  ],
+  "credits": [
+    {
+      "name": "LPM Security Firewall",
+      "type": "FINDER",
+      "contact": [
+        "https://firewall.lpm.dev"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "bronze-improved-gibbon-411.mypinata.cloud"
+      ],
+      "urls": [
+        "https://bronze-improved-gibbon-411.mypinata.cloud/ipfs/bafkreigjnxn5vnn34rc5r43ajwwkmk4akqpm4awmq5gdhakgszpeqiffsu"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a malicious-package OSV report for `react-next-vite@1.2.9`.

Source report: https://firewall.lpm.dev/npm/react-next-vite/v/1.2.9

Evidence summary:
- `package.json` sets `index.js` as the package main entrypoint.
- Calling the exported middleware/factory in `index.js` starts a detached Node child process for `lib/caller.js` with ignored stdio and `child.unref()`.
- `lib/caller.js` fetches a remote object from a Pinata/IPFS gateway URL and executes `data.cookie` through `new Function.constructor("require", s)`, giving the remote payload `require` access in the consumer environment.
- LPM Firewall independently classified the package as malicious/block with low false-positive risk and matched `index.js` to a known malicious source fingerprint.

Local checks:
- `jq` parse check passed.
- Lightweight local advisory checks passed.
- Could not run `make validate` locally because Go is not installed on this machine; GitHub Actions should run the official OpenSSF validator.