### PR TITLE
Add malicious npm package na-rony-test-karem

### DIFF
--- a/osv/malicious/npm/na-rony-test-karem/MAL-0000-na-rony-test-karem.json
+++ b/osv/malicious/npm/na-rony-test-karem/MAL-0000-na-rony-test-karem.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-08T07:02:50Z",
+  "published": "2026-07-08T07:02:50Z",
+  "details": "The npm package na-rony-test-karem version 99.9.9 performs import-time host fingerprint exfiltration. package.json sets index.js as the package main entrypoint. When index.js is loaded, it constructs a JSON payload containing the local username from os.userInfo().username, the current project path from INIT_CWD or process.cwd(), and the hostname from os.hostname(). It then sends that payload with https.request to an external webhook.site endpoint. This leaks developer or CI host identity and project path context to an attacker-controlled endpoint without user consent. The package.json script key is misspelled as postinsatll, so the behavior is not a valid npm install lifecycle hook, but it is reachable whenever user or dependent code imports the package main entrypoint.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "na-rony-test-karem",
+        "purl": "pkg:npm/na-rony-test-karem"
+      },
+      "versions": [
+        "99.9.9"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          },
+          {
+            "cweId": "CWE-200",
+            "description": "The product exposes sensitive information to an actor that is not explicitly authorized to have access to that information.",
+            "name": "Exposure of Sensitive Information to an Unauthorized Actor"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/na-rony-test-karem/v/99.9.9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://firewall.lpm.dev/npm/na-rony-test-karem/v/99.9.9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://unpkg.com/na-rony-test-karem@99.9.9/index.js"
+    }
+  ],
+  "credits": [
+    {
+      "name": "LPM Security Firewall",
+      "type": "FINDER",
+      "contact": [
+        "https://firewall.lpm.dev"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "webhook.site"
+      ],
+      "urls": [
+        "https://webhook.site/497a0910-6799-4216-976a-fe08154de047"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a malicious-package OSV report for `na-rony-test-karem@99.9.9`.

Source report: https://firewall.lpm.dev/npm/na-rony-test-karem/v/99.9.9

Evidence summary:
- `package.json` sets `index.js` as the package main entrypoint.
- Importing/requiring `index.js` constructs a JSON payload containing `os.userInfo().username`, `process.env.INIT_CWD || process.cwd()`, and `os.hostname()`.
- `index.js` sends that payload via `https.request` to `https://webhook.site/497a0910-6799-4216-976a-fe08154de047`, leaking developer or CI host identity and project path context.
- The package has a misspelled `postinsatll` script, so this is not a valid npm install hook; the malicious behavior is still reachable through the package main entrypoint.
- LPM Firewall classified the package as malicious/block with low false-positive risk.

Local checks:
- `jq` parse check passed.
- Lightweight local advisory checks passed.
- The unpkg source reference returned 200.
- Could not run `make validate` locally because Go is not installed on this machine; GitHub Actions should run the official OpenSSF validator.