### PR TITLE
Add malicious npm package testudo-pack

### DIFF
--- a/osv/malicious/npm/testudo-pack/MAL-0000-testudo-pack.json
+++ b/osv/malicious/npm/testudo-pack/MAL-0000-testudo-pack.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-07-08T09:04:03Z",
+  "published": "2026-07-08T09:04:03Z",
+  "details": "The npm package testudo-pack version 1.0.0 contains a concealed runtime remote-code-execution payload. package.json sets index.js as the package main entrypoint and defines postinstall: node index.js, but direct source inspection shows index.js does not call the payload at top level during postinstall. The malicious behavior is triggered when user or dependent code calls the exported pack() function. pack() invokes _fetch(), which resolves an obfuscated sloth-antagonist.vercel.app host and OS-specific asset path, downloads a remote binary, writes it outside the package into a WinMetrics directory under LOCALAPPDATA on Windows or HOME/.local/share on Linux, marks the Linux payload executable, and starts the downloaded binary detached with ignored stdio. This behavior is unrelated to the package's visible packing/checksum API and gives the remote endpoint control over executed code under the user's account.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "testudo-pack",
+        "purl": "pkg:npm/testudo-pack"
+      },
+      "versions": [
+        "1.0.0"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          },
+          {
+            "cweId": "CWE-94",
+            "description": "The product constructs code from externally-controlled input and executes it.",
+            "name": "Improper Control of Generation of Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/testudo-pack/v/1.0.0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://firewall.lpm.dev/npm/testudo-pack/v/1.0.0"
+    },
+    {
+      "type": "WEB",
+      "url": "https://unpkg.com/testudo-pack@1.0.0/package.json"
+    },
+    {
+      "type": "WEB",
+      "url": "https://unpkg.com/testudo-pack@1.0.0/index.js"
+    }
+  ],
+  "credits": [
+    {
+      "name": "LPM Security Firewall",
+      "type": "FINDER",
+      "contact": [
+        "https://firewall.lpm.dev"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "sloth-antagonist.vercel.app"
+      ],
+      "urls": [
+        "https://sloth-antagonist.vercel.app/service/assets/fetchBinary",
+        "https://sloth-antagonist.vercel.app/service/assets/fetchLinuxBinary"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a malicious-package OSV report for `testudo-pack@1.0.0`.

Source report: https://firewall.lpm.dev/npm/testudo-pack/v/1.0.0

Evidence summary:
- `package.json` sets `index.js` as the package main entrypoint and defines `postinstall: node index.js`.
- Direct source inspection shows `index.js` does not call the payload at top level during postinstall; the malicious behavior is triggered when user or dependent code calls exported `pack()`.
- `pack()` calls `_fetch()`, which resolves an obfuscated `sloth-antagonist.vercel.app` host and OS-specific payload path.
- `_fetch()` downloads a remote binary into a `WinMetrics` directory under `%LOCALAPPDATA%/Programs` on Windows or `$HOME/.local/share` on Linux.
- The Linux payload is marked executable, then the downloaded binary is started detached with ignored stdio.
- LPM Firewall classified the package as malicious/block with low false-positive risk.

Local checks:
- `jq` parse check passed.
- Lightweight local advisory checks passed.
- The unpkg source references returned 200.
- Could not run `make validate` locally because Go is not installed on this machine; GitHub Actions should run the official OpenSSF validator.