### PR TITLE
Add LPM Firewall credits to npm malware advisories

### DIFF
--- a/osv/malicious/npm/na-rony-test-karem/MAL-2026-6966.json
+++ b/osv/malicious/npm/na-rony-test-karem/MAL-2026-6966.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-07-08T08:26:03Z",
+  "modified": "2026-07-14T11:16:06Z",
   "published": "2026-07-08T08:26:02Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-6966",
@@ -39,6 +39,19 @@
     {
       "type": "ADVISORY",
       "url": "https://github.com/advisories/GHSA-pfc9-hmhj-8x4p"
+    },
+    {
+      "type": "WEB",
+      "url": "https://firewall.lpm.dev/npm/na-rony-test-karem/v/99.9.9"
+    }
+  ],
+  "credits": [
+    {
+      "name": "LPM Firewall",
+      "type": "FINDER",
+      "contact": [
+        "https://firewall.lpm.dev"
+      ]
     }
   ],
   "database_specific": {

--- a/osv/malicious/npm/react-next-vite/MAL-2026-10211.json
+++ b/osv/malicious/npm/react-next-vite/MAL-2026-10211.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-07-12T20:48:42Z",
+  "modified": "2026-07-14T11:16:06Z",
   "published": "2026-07-12T20:48:42Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-10211",
@@ -52,6 +52,10 @@
     {
       "type": "PACKAGE",
       "url": "https://www.npmjs.com/package/react-next-vite/v/1.2.9"
+    },
+    {
+      "type": "WEB",
+      "url": "https://firewall.lpm.dev/npm/react-next-vite/v/1.2.9"
     }
   ],
   "credits": [
@@ -60,6 +64,13 @@
       "type": "FINDER",
       "contact": [
         "inspector-research@amazon.com"
+      ]
+    },
+    {
+      "name": "LPM Firewall",
+      "type": "FINDER",
+      "contact": [
+        "https://firewall.lpm.dev"
       ]
     }
   ],

--- a/osv/malicious/npm/testis-pack/MAL-2026-10074.json
+++ b/osv/malicious/npm/testis-pack/MAL-2026-10074.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-07-13T06:50:51Z",
+  "modified": "2026-07-14T11:16:06Z",
   "published": "2026-07-09T00:00:00Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-10074",
@@ -66,6 +66,10 @@
     {
       "type": "PACKAGE",
       "url": "https://www.npmjs.com/package/testis-pack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://firewall.lpm.dev/npm/testis-pack/v/1.0.0"
     }
   ],
   "credits": [
@@ -81,6 +85,13 @@
       "type": "FINDER",
       "contact": [
         "https://safedep.io"
+      ]
+    },
+    {
+      "name": "LPM Firewall",
+      "type": "FINDER",
+      "contact": [
+        "https://firewall.lpm.dev"
       ]
     }
   ],

--- a/osv/malicious/npm/testudo-pack/MAL-2026-10075.json
+++ b/osv/malicious/npm/testudo-pack/MAL-2026-10075.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-07-13T06:50:51Z",
+  "modified": "2026-07-14T11:16:06Z",
   "published": "2026-07-09T00:00:00Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-10075",
@@ -66,6 +66,10 @@
     {
       "type": "PACKAGE",
       "url": "https://www.npmjs.com/package/testudo-pack"
+    },
+    {
+      "type": "WEB",
+      "url": "https://firewall.lpm.dev/npm/testudo-pack/v/1.0.0"
     }
   ],
   "credits": [
@@ -81,6 +85,13 @@
       "type": "FINDER",
       "contact": [
         "https://safedep.io"
+      ]
+    },
+    {
+      "name": "LPM Firewall",
+      "type": "FINDER",
+      "contact": [
+        "https://firewall.lpm.dev"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Updates existing OpenSSF malicious-package advisories to include LPM Firewall as an additional finder and adds the corresponding public LPM report pages as references.

This follows maintainer guidance on the earlier duplicate/new-advisory PRs:

- #1354 -> merge into existing `react-next-vite` advisory
- #1356 -> modify contributors on existing `na-rony-test-karem` advisory
- #1357 / #1358 -> existing `testudo-pack` and `testis-pack` advisories were merged via #1363, with credits open to adjustment because the earlier reports were submitted first

## Updated advisories

- `react-next-vite`: `MAL-2026-10211`
- `na-rony-test-karem`: `MAL-2026-6966`
- `testudo-pack`: `MAL-2026-10075`
- `testis-pack`: `MAL-2026-10074`

## Validation

- Parsed all four modified JSON files successfully with Node.js `JSON.parse`.

