### PR TITLE
Block usage of ecosystem_specific.

### DIFF
--- a/internal/report/validate.go
+++ b/internal/report/validate.go
@@ -103,6 +103,11 @@ func validateVulnInternal(v *osvschema.Vulnerability, allowMultiple bool) error 
 			repos := slices.Collect(maps.Keys(repoSet))
 			return fmt.Errorf("%w: git-based report has multiple repos: %s", ErrUnexpectedOSV, repos)
 		}
+
+		// Ensure ecosystem specific data is not present.
+		if es := v.Affected[i].EcosystemSpecific; len(es) > 0 {
+			return fmt.Errorf("%w: ecosystem_specific must not be set", ErrUnexpectedOSV)
+		}
 	}
 
 	return nil

--- a/internal/report/validate_test.go
+++ b/internal/report/validate_test.go
@@ -26,7 +26,8 @@ func TestValidateVuln_Valid(t *testing.T) {
 						},
 					},
 				},
-				Versions: []string{"0", "0.1"},
+				Versions:          []string{"0", "0.1"},
+				EcosystemSpecific: make(map[string]any),
 			},
 		},
 	}
@@ -502,5 +503,26 @@ func TestValidateVuln_Fail_InvalidPURLs(t *testing.T) {
 				t.Error("ValidateVuln() == nil; want err")
 			}
 		})
+	}
+}
+
+func TestValidateVuln_Fail_EcosystemSpecific(t *testing.T) {
+	vuln := &osvschema.Vulnerability{
+		Affected: []osvschema.Affected{
+			{
+				Package: osvschema.Package{
+					Ecosystem: string(osvschema.EcosystemPyPI),
+					Name:      "example",
+				},
+				EcosystemSpecific: map[string]any{
+					"test": "not empty",
+				},
+			},
+		},
+	}
+	err := report.ValidateVuln(vuln)
+
+	if err == nil {
+		t.Error("ValidateVuln() == nil; want err")
 	}
 }


### PR DESCRIPTION
This field is currently unused, and merge does make it nil. But a single report could populate the field.

Blocking usage prevents any new reports using the field in a way that needs feedback or management.