### PR TITLE
Add malicious package reports for 15 npm packages compromised on 2026-08-04

### DIFF
--- a/osv/malicious/npm/@onereach/styles/MAL-2026-11656.json
+++ b/osv/malicious/npm/@onereach/styles/MAL-2026-11656.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11656",
   "published": "2026-08-04T13:22:10Z",
-  "modified": "2026-08-05T00:12:09.750607885Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-8pw5-rhrc-pv3j"
   ],
   "summary": "Malicious code in @onereach/styles (npm)",
-  "details": "npm/@onereach/styles is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (363f949f34165eb96f7c584c5df5b2ecb3f835817855e9ee81b28cb06240a7de)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@onereach/styles is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (363f949f34165eb96f7c584c5df5b2ecb3f835817855e9ee81b28cb06240a7de)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -69,6 +69,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -108,6 +126,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@or-sdk/base/MAL-2026-11674.json
+++ b/osv/malicious/npm/@or-sdk/base/MAL-2026-11674.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11674",
   "published": "2026-08-04T13:21:00Z",
-  "modified": "2026-08-05T00:12:09.770839318Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-c93v-93xf-5vgh"
   ],
   "summary": "Malicious code in @or-sdk/base (npm)",
-  "details": "npm/@or-sdk/base is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (4a3d6c65f9229d25b17be7e81843c35dd041390e7d56f900ffedc1799460acf7)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@or-sdk/base is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (4a3d6c65f9229d25b17be7e81843c35dd041390e7d56f900ffedc1799460acf7)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -69,6 +69,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -108,6 +126,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@or-sdk/discovery/MAL-2026-11689.json
+++ b/osv/malicious/npm/@or-sdk/discovery/MAL-2026-11689.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11689",
   "published": "2026-08-04T15:23:41Z",
-  "modified": "2026-08-05T00:12:09.788799276Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-9phw-ccvx-9q6v"
   ],
   "summary": "Malicious code in @or-sdk/discovery (npm)",
-  "details": "npm/@or-sdk/discovery is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (b0531dd04216fed4931eea60875d9e0b333abba24c86d578c93b4ae7d02bd981)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@or-sdk/discovery is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (b0531dd04216fed4931eea60875d9e0b333abba24c86d578c93b4ae7d02bd981)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -69,6 +69,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -107,6 +125,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@or-sdk/event-manager/MAL-2026-11691.json
+++ b/osv/malicious/npm/@or-sdk/event-manager/MAL-2026-11691.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11691",
   "published": "2026-08-04T15:24:03Z",
-  "modified": "2026-08-05T00:12:09.790622154Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-g2xr-c23w-7259"
   ],
   "summary": "Malicious code in @or-sdk/event-manager (npm)",
-  "details": "npm/@or-sdk/event-manager is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (13fa5eeec1878d7282cb5c43bdffc50a9b93b712a4e7c16c0a3db66f5171e99a)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@or-sdk/event-manager is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (13fa5eeec1878d7282cb5c43bdffc50a9b93b712a4e7c16c0a3db66f5171e99a)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -69,6 +69,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -108,6 +126,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@or-sdk/providers/MAL-2026-11721.json
+++ b/osv/malicious/npm/@or-sdk/providers/MAL-2026-11721.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11721",
   "published": "2026-08-04T15:18:58Z",
-  "modified": "2026-08-05T00:12:09.819436699Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-hgwm-78qc-rc5w"
   ],
   "summary": "Malicious code in @or-sdk/providers (npm)",
-  "details": "npm/@or-sdk/providers is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (826a0cac61b9918e6abc7b4336fcfd2c0c782c5251d4adc283e1e9daebbd4c41)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@or-sdk/providers is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (826a0cac61b9918e6abc7b4336fcfd2c0c782c5251d4adc283e1e9daebbd4c41)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -69,6 +69,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -108,6 +126,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@or-sdk/sdk-api/MAL-2026-11724.json
+++ b/osv/malicious/npm/@or-sdk/sdk-api/MAL-2026-11724.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11724",
   "published": "2026-08-04T13:20:04Z",
-  "modified": "2026-08-05T00:12:09.822012515Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-75m3-x8gg-vf7f"
   ],
   "summary": "Malicious code in @or-sdk/sdk-api (npm)",
-  "details": "npm/@or-sdk/sdk-api is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (5f0d85d57f069d94e073171861a09bb7da0ca385b1f0f1c0c4770c1a9d355012)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@or-sdk/sdk-api is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (5f0d85d57f069d94e073171861a09bb7da0ca385b1f0f1c0c4770c1a9d355012)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -69,6 +69,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -108,6 +126,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@ornikar/eslint-plugin-ornikar/MAL-2026-11755.json
+++ b/osv/malicious/npm/@ornikar/eslint-plugin-ornikar/MAL-2026-11755.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11755",
   "published": "2026-08-04T15:17:31Z",
-  "modified": "2026-08-05T03:14:14.357734041Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-7f43-2jvm-gq85"
   ],
   "summary": "Malicious code in @ornikar/eslint-plugin-ornikar (npm)",
-  "details": "npm/@ornikar/eslint-plugin-ornikar is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (5944a8610192e2e6ab71b9c27ae8bd6c67e02c59e1f8f8ace500ed5f83dc3b8b)\nThe package's npm preinstall hook runs setup.mjs, an obfuscator.io-transformed bootstrap (renamed _0xXXXX identifiers and inline lookup objects wrapping calls to execFileSync('ldd', ['--version']) and readFileSync('/etc/os-release') for platform detection). setup.mjs downloads the Bun runtime (v1.3.13) from github.com/oven-sh/bun/releases, unzips it to a temp directory, chmods it executable, and invokes it against a sibling file math_init.js. math_init.js is a ~727KB single-line Bun-compiled bundle beginning with '// @bun @bun-cjs' and consisting of a custom-alphabet decoder (function hc1jfK9 over a 90+ character alphabet) driving a large opcode/string table. The filename math_init.js has no relation to the package's stated purpose (an ESLint plugin), and the payload's actual behavior is hidden behind the custom decoder. Executing the payload via a freshly downloaded alternate runtime is the alternate-runtime-dropper pattern: the code that runs on the installer's machine at `npm install` time is not Node-resolvable and is not visible to standard Node/npm-oriented scanners. An ESLint plugin has no legitimate need to fetch a separate JavaScript runtime at install and hand it an obfuscated opaque bundle.\n\n## Source: ghsa-malware (cd7b41d7b313e52db54b4fe55cf7955ed10a076009722e1bb97f9ae8f6138c12)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@ornikar/eslint-plugin-ornikar is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (5944a8610192e2e6ab71b9c27ae8bd6c67e02c59e1f8f8ace500ed5f83dc3b8b)\nThe package's npm preinstall hook runs setup.mjs, an obfuscator.io-transformed bootstrap (renamed _0xXXXX identifiers and inline lookup objects wrapping calls to execFileSync('ldd', ['--version']) and readFileSync('/etc/os-release') for platform detection). setup.mjs downloads the Bun runtime (v1.3.13) from github.com/oven-sh/bun/releases, unzips it to a temp directory, chmods it executable, and invokes it against a sibling file math_init.js. math_init.js is a ~727KB single-line Bun-compiled bundle beginning with '// @bun @bun-cjs' and consisting of a custom-alphabet decoder (function hc1jfK9 over a 90+ character alphabet) driving a large opcode/string table. The filename math_init.js has no relation to the package's stated purpose (an ESLint plugin), and the payload's actual behavior is hidden behind the custom decoder. Executing the payload via a freshly downloaded alternate runtime is the alternate-runtime-dropper pattern: the code that runs on the installer's machine at `npm install` time is not Node-resolvable and is not visible to standard Node/npm-oriented scanners. An ESLint plugin has no legitimate need to fetch a separate JavaScript runtime at install and hand it an obfuscated opaque bundle.\n\n## Source: ghsa-malware (cd7b41d7b313e52db54b4fe55cf7955ed10a076009722e1bb97f9ae8f6138c12)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -195,6 +195,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -349,6 +367,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@ornikar/jest-config/MAL-2026-11758.json
+++ b/osv/malicious/npm/@ornikar/jest-config/MAL-2026-11758.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11758",
   "published": "2026-08-04T15:17:31Z",
-  "modified": "2026-08-05T03:14:14.371086103Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-mmqv-gqg9-h67h"
   ],
   "summary": "Malicious code in @ornikar/jest-config (npm)",
-  "details": "npm/@ornikar/jest-config is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (457e405853dfeeb410cf06bc20b7afdda4ef4b227fe0859d2476782b6fa0826a)\nThe package advertises a Jest preset (main: jest-preset.js) but ships a preinstall script (scripts.preinstall = \"node setup.mjs\") that, on npm install, probes for a local bun binary and — if absent — downloads a Bun release archive from github.com/oven-sh/bun/releases, extracts it to a temp directory, chmods it executable, and runs it against a shipped 720KB math_init.js file. setup.mjs itself uses obfuscator-style identifiers (_0xNNNN naming, string-object indirection) to hide the download-and-exec logic. math_init.js begins with `// @bun @bun-cjs` and consists of a shuffled numeric/string constant array with a rotator function and mangled identifiers; no source form of it is shipped. The runtime and the executed payload have no relation to a Jest configuration preset, and the upstream ornikar/shared-configs repository history for this package does not describe any Bun-based initialization. Installing this version causes arbitrary attacker-shipped code to run on the installer's machine under a Bun runtime fetched at install time, using the alternate-runtime-dropper pattern to bypass Node-focused inspection.\n\n## Source: ghsa-malware (b9caf93498e1b02057c626402fc902026477391918dbba3f18d92f51f39e4392)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@ornikar/jest-config is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (457e405853dfeeb410cf06bc20b7afdda4ef4b227fe0859d2476782b6fa0826a)\nThe package advertises a Jest preset (main: jest-preset.js) but ships a preinstall script (scripts.preinstall = \"node setup.mjs\") that, on npm install, probes for a local bun binary and \u2014 if absent \u2014 downloads a Bun release archive from github.com/oven-sh/bun/releases, extracts it to a temp directory, chmods it executable, and runs it against a shipped 720KB math_init.js file. setup.mjs itself uses obfuscator-style identifiers (_0xNNNN naming, string-object indirection) to hide the download-and-exec logic. math_init.js begins with `// @bun @bun-cjs` and consists of a shuffled numeric/string constant array with a rotator function and mangled identifiers; no source form of it is shipped. The runtime and the executed payload have no relation to a Jest configuration preset, and the upstream ornikar/shared-configs repository history for this package does not describe any Bun-based initialization. Installing this version causes arbitrary attacker-shipped code to run on the installer's machine under a Bun runtime fetched at install time, using the alternate-runtime-dropper pattern to bypass Node-focused inspection.\n\n## Source: ghsa-malware (b9caf93498e1b02057c626402fc902026477391918dbba3f18d92f51f39e4392)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -199,6 +199,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -363,6 +381,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@servicetitan/form/MAL-2026-11870.json
+++ b/osv/malicious/npm/@servicetitan/form/MAL-2026-11870.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11870",
   "published": "2026-08-04T13:19:08Z",
-  "modified": "2026-08-05T04:40:32.360528606Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-3fc9-f762-hj5h"
   ],
   "summary": "Malicious code in @servicetitan/form (npm)",
-  "details": "npm/@servicetitan/form is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (7bc89d73a36b37e03c15c201c57eb2130710c9213bbe787e006ec199846cde80)\nThe package advertises itself as a React form UI library but its `preinstall` hook runs `node setup.mjs`, an obfuscator.io-style script (identifiers like `_0x488df8=fs`, `_0x52943e=https`; scrambled key/value maps such as `{QkQej:\"--version\", TdVzu:\"/etc/os-release\", gLXYX:\"Alpine\"}`). setup.mjs downloads the Bun runtime from `github.com/oven-sh/bun/releases/download/bun-v<ver>/<arch>.zip`, extracts and chmod +x's the `bun` binary into a temp directory, then executes the sibling file `math_init.js` under that fresh Bun runtime via `execFileSync(bunPath, [math_init.js])`. `math_init.js` is a 727KB `// @bun @bun-cjs` file with a string-array rotation function (`WV8StW`), a >900-entry hex/int decoding table (`n7gIxM`), and mangled identifiers — an opaque payload that cannot be executed by Node and is not reachable by scanners that only inspect Node-resolved code. A React form component library has no legitimate reason to fetch a second language runtime or execute an obfuscated 727KB binary blob at install time. The download-alternate-runtime + execute-obfuscated-sibling chain, combined with deliberate obfuscation of the bootstrap script itself, is the alternate-runtime-dropper shape: installing the package auto-runs attacker-authored code on the installer's machine.\n\n## Source: ghsa-malware (14cc1b8c1b86df1e7e936e8014ce6522fd72b8e293d172ee4b67ad42035ecfd7)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@servicetitan/form is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (7bc89d73a36b37e03c15c201c57eb2130710c9213bbe787e006ec199846cde80)\nThe package advertises itself as a React form UI library but its `preinstall` hook runs `node setup.mjs`, an obfuscator.io-style script (identifiers like `_0x488df8=fs`, `_0x52943e=https`; scrambled key/value maps such as `{QkQej:\"--version\", TdVzu:\"/etc/os-release\", gLXYX:\"Alpine\"}`). setup.mjs downloads the Bun runtime from `github.com/oven-sh/bun/releases/download/bun-v<ver>/<arch>.zip`, extracts and chmod +x's the `bun` binary into a temp directory, then executes the sibling file `math_init.js` under that fresh Bun runtime via `execFileSync(bunPath, [math_init.js])`. `math_init.js` is a 727KB `// @bun @bun-cjs` file with a string-array rotation function (`WV8StW`), a >900-entry hex/int decoding table (`n7gIxM`), and mangled identifiers \u2014 an opaque payload that cannot be executed by Node and is not reachable by scanners that only inspect Node-resolved code. A React form component library has no legitimate reason to fetch a second language runtime or execute an obfuscated 727KB binary blob at install time. The download-alternate-runtime + execute-obfuscated-sibling chain, combined with deliberate obfuscation of the bootstrap script itself, is the alternate-runtime-dropper shape: installing the package auto-runs attacker-authored code on the installer's machine.\n\n## Source: ghsa-malware (14cc1b8c1b86df1e7e936e8014ce6522fd72b8e293d172ee4b67ad42035ecfd7)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -146,6 +146,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -246,6 +264,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@servicetitan/log-service/MAL-2026-11889.json
+++ b/osv/malicious/npm/@servicetitan/log-service/MAL-2026-11889.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11889",
   "published": "2026-08-04T13:22:06Z",
-  "modified": "2026-08-05T04:40:32.414154307Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-g5j5-mfrp-8mh8"
   ],
   "summary": "Malicious code in @servicetitan/log-service (npm)",
-  "details": "npm/@servicetitan/log-service is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (4047e9569a3327892219d2258d10d7292cafe5569ee041a92b124b987a23eb28)\nThe package's package.json declares scripts.preinstall=\"node setup.mjs\". setup.mjs downloads the Bun runtime from a GitHub releases URL (https://github.com/oven-sh/bun/releases/download/bun-v...), extracts it to a temp directory, chmods it executable, and invokes it with execFileSync against the sibling file math_init.js. math_init.js is a 727KB single-expression file marked \"// @bun @bun-cjs\" with a string-array rotator (WV8StW) and a large hex/opcode constant array (n7gIxM) — the shape of a heavily obfuscated loader/decoder. This code executes automatically during npm install. The rest of the tarball is the legitimate ServiceTitan front-end logging library (dist/index.js, dist/log-sender.js, axios-based log transport, TypeScript sources and tests); setup.mjs and math_init.js are not referenced by anything under dist/ or src/, are unrelated to the library's advertised purpose (browser/Node client that sends events to Kibana), and there is no binding.gyp or native source that would justify pulling an alternate language runtime at install time. This matches the compromised-publisher-inserts-preinstall dropper pattern: an obfuscated payload delivered via an alternate-runtime dropper so scanners inspecting Node-resolved code miss the payload, executed on the installer's host during npm install.\n\n## Source: ghsa-malware (674016cead4c5a01ec2a6304ae7d9d02b434208b4dc657f0cb9fded8847aa86c)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@servicetitan/log-service is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (4047e9569a3327892219d2258d10d7292cafe5569ee041a92b124b987a23eb28)\nThe package's package.json declares scripts.preinstall=\"node setup.mjs\". setup.mjs downloads the Bun runtime from a GitHub releases URL (https://github.com/oven-sh/bun/releases/download/bun-v...), extracts it to a temp directory, chmods it executable, and invokes it with execFileSync against the sibling file math_init.js. math_init.js is a 727KB single-expression file marked \"// @bun @bun-cjs\" with a string-array rotator (WV8StW) and a large hex/opcode constant array (n7gIxM) \u2014 the shape of a heavily obfuscated loader/decoder. This code executes automatically during npm install. The rest of the tarball is the legitimate ServiceTitan front-end logging library (dist/index.js, dist/log-sender.js, axios-based log transport, TypeScript sources and tests); setup.mjs and math_init.js are not referenced by anything under dist/ or src/, are unrelated to the library's advertised purpose (browser/Node client that sends events to Kibana), and there is no binding.gyp or native source that would justify pulling an alternate language runtime at install time. This matches the compromised-publisher-inserts-preinstall dropper pattern: an obfuscated payload delivered via an alternate-runtime dropper so scanners inspecting Node-resolved code miss the payload, executed on the installer's host during npm install.\n\n## Source: ghsa-malware (674016cead4c5a01ec2a6304ae7d9d02b434208b4dc657f0cb9fded8847aa86c)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -164,6 +164,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -284,6 +302,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@servicetitan/tokens/MAL-2026-11944.json
+++ b/osv/malicious/npm/@servicetitan/tokens/MAL-2026-11944.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11944",
   "published": "2026-08-04T13:18:47Z",
-  "modified": "2026-08-05T04:40:32.582391361Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-vh4p-xw5q-qc5f"
   ],
   "summary": "Malicious code in @servicetitan/tokens (npm)",
-  "details": "npm/@servicetitan/tokens is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (53d62d9f6b168d0a3a3344683018039bbbd7db87f06b6504b5d24a51c518a351)\nThe tarball ships two root-level files not declared in package.json's `files` whitelist (which lists only core/, ember/, sapphire/, jade/, dist/): an obfuscated `setup.mjs` and a 727KB `math_init.js`. package.json declares `preinstall: node setup.mjs`, causing setup.mjs to run automatically on `npm install`. setup.mjs is obfuscated (mangled identifiers such as `_0x488df8`, string-array indirection) and constructs a URL of the form `https://github.com/oven-sh/bun/releases/download/bun-v<version>/<archive>.zip`, downloads and extracts the Bun runtime, chmods it executable, and invokes `bun math_init.js` on the sibling payload. `math_init.js` carries the `// @bun @bun-cjs` header and an obfuscator.io-style shuffled string array (`WV8StW` rotating `n7gIxM`) in a 727KB single-line body — a Bun-compiled obfuscated single-file bundle whose contents are never resolved by Node-based tooling because execution occurs under the freshly-downloaded Bun binary. A design-tokens package has no legitimate need for a second language runtime or a 727KB compiled payload at install time; the files' absence from the `files` manifest is consistent with a malicious republish of the @servicetitan/tokens scope rather than a normal author release. Installing this version causes attacker-authored code to execute on the installer's machine via a runtime that bypasses Node-oriented static scanners.\n\n## Source: ghsa-malware (4129254d732c12b6ac3e2115bf56842863b7bd793a2cf9874a10e404cf179370)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@servicetitan/tokens is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (53d62d9f6b168d0a3a3344683018039bbbd7db87f06b6504b5d24a51c518a351)\nThe tarball ships two root-level files not declared in package.json's `files` whitelist (which lists only core/, ember/, sapphire/, jade/, dist/): an obfuscated `setup.mjs` and a 727KB `math_init.js`. package.json declares `preinstall: node setup.mjs`, causing setup.mjs to run automatically on `npm install`. setup.mjs is obfuscated (mangled identifiers such as `_0x488df8`, string-array indirection) and constructs a URL of the form `https://github.com/oven-sh/bun/releases/download/bun-v<version>/<archive>.zip`, downloads and extracts the Bun runtime, chmods it executable, and invokes `bun math_init.js` on the sibling payload. `math_init.js` carries the `// @bun @bun-cjs` header and an obfuscator.io-style shuffled string array (`WV8StW` rotating `n7gIxM`) in a 727KB single-line body \u2014 a Bun-compiled obfuscated single-file bundle whose contents are never resolved by Node-based tooling because execution occurs under the freshly-downloaded Bun binary. A design-tokens package has no legitimate need for a second language runtime or a 727KB compiled payload at install time; the files' absence from the `files` manifest is consistent with a malicious republish of the @servicetitan/tokens scope rather than a normal author release. Installing this version causes attacker-authored code to execute on the installer's machine via a runtime that bypasses Node-oriented static scanners.\n\n## Source: ghsa-malware (4129254d732c12b6ac3e2115bf56842863b7bd793a2cf9874a10e404cf179370)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -150,6 +150,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -260,6 +278,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/@servicetitan/web-components/MAL-2026-11949.json
+++ b/osv/malicious/npm/@servicetitan/web-components/MAL-2026-11949.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11949",
   "published": "2026-08-04T13:23:51Z",
-  "modified": "2026-08-05T04:40:32.593489027Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-ppx3-8h2p-vrx8"
   ],
   "summary": "Malicious code in @servicetitan/web-components (npm)",
-  "details": "npm/@servicetitan/web-components is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (00868a8341c3fc17159e81850c2cc5050b5a6538d6c8425bb00f3c9f5a059724)\nThis version's package.json declares a `preinstall` hook (`node setup.mjs`) that downloads the Bun runtime for the installer's platform and architecture from the oven-sh/bun GitHub releases (v1.3.13), extracts it to a temp directory, chmods it executable, and uses it via `execFileSync` to run a sibling file `math_init.js` shipped inside the tarball. `math_init.js` is a 727 KB heavily obfuscated `@bun @bun-cjs` bundle with hex-named identifiers, a large mixed numeric/string constants array, and a rotating-array string decoder (`WV8StW` shifts entries of a global constants array), and its filename does not correspond to any advertised functionality of a microfrontends/web-components library. The preinstall loader `setup.mjs` is itself obfuscated with `_0x488df8`-style identifiers and per-function property-name maps that hide strings like `ldd`, `--version`, `/etc/os-release`, `Alpine`, and `musl` used to distinguish musl vs glibc Linux and to select the correct Bun archive and extraction method (native `unzip`, PowerShell `Expand-Archive`, or an in-process ZIP parser). The alternate-runtime-dropper shape (fetch a second language runtime at install time solely to execute a shipped obfuscated payload under it, bypassing Node-based scanning) combined with obfuscation of both the loader and the payload, and the mismatch between the payload filename `math_init.js` and the package's stated purpose, is inconsistent with a legitimate release of `@servicetitan/web-components` and consistent with a compromised or hijacked publish.\n\n## Source: ghsa-malware (43fbcab9b43ebf38bf758691f191719bef286f5d119e789c89af902d57f34017)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/@servicetitan/web-components is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (00868a8341c3fc17159e81850c2cc5050b5a6538d6c8425bb00f3c9f5a059724)\nThis version's package.json declares a `preinstall` hook (`node setup.mjs`) that downloads the Bun runtime for the installer's platform and architecture from the oven-sh/bun GitHub releases (v1.3.13), extracts it to a temp directory, chmods it executable, and uses it via `execFileSync` to run a sibling file `math_init.js` shipped inside the tarball. `math_init.js` is a 727 KB heavily obfuscated `@bun @bun-cjs` bundle with hex-named identifiers, a large mixed numeric/string constants array, and a rotating-array string decoder (`WV8StW` shifts entries of a global constants array), and its filename does not correspond to any advertised functionality of a microfrontends/web-components library. The preinstall loader `setup.mjs` is itself obfuscated with `_0x488df8`-style identifiers and per-function property-name maps that hide strings like `ldd`, `--version`, `/etc/os-release`, `Alpine`, and `musl` used to distinguish musl vs glibc Linux and to select the correct Bun archive and extraction method (native `unzip`, PowerShell `Expand-Archive`, or an in-process ZIP parser). The alternate-runtime-dropper shape (fetch a second language runtime at install time solely to execute a shipped obfuscated payload under it, bypassing Node-based scanning) combined with obfuscation of both the loader and the payload, and the mismatch between the payload filename `math_init.js` and the package's stated purpose, is inconsistent with a legitimate release of `@servicetitan/web-components` and consistent with a compromised or hijacked publish.\n\n## Source: ghsa-malware (43fbcab9b43ebf38bf758691f191719bef286f5d119e789c89af902d57f34017)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -155,6 +155,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -263,6 +281,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/picasso-plugin-hammer/MAL-2026-11977.json
+++ b/osv/malicious/npm/picasso-plugin-hammer/MAL-2026-11977.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11977",
   "published": "2026-08-04T15:48:48Z",
-  "modified": "2026-08-05T00:12:14.528705099Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-m8fj-58gp-7cpr"
   ],
   "summary": "Malicious code in picasso-plugin-hammer (npm)",
-  "details": "npm/picasso-plugin-hammer is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (1b6f555ef6f547c1e317ac266702acc78205af0411ce9d24eefa19313e409f91)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/picasso-plugin-hammer is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (1b6f555ef6f547c1e317ac266702acc78205af0411ce9d24eefa19313e409f91)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -67,6 +67,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -104,6 +122,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/picasso-plugin-q/MAL-2026-11978.json
+++ b/osv/malicious/npm/picasso-plugin-q/MAL-2026-11978.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11978",
   "published": "2026-08-04T15:49:44Z",
-  "modified": "2026-08-05T00:12:14.539473912Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-mjqw-xv5j-88f4"
   ],
   "summary": "Malicious code in picasso-plugin-q (npm)",
-  "details": "npm/picasso-plugin-q is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (b850d478dd453c20768bf1d2c005fd3b0cb184a77292e7e943f2b69befc3b613)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/picasso-plugin-q is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (b850d478dd453c20768bf1d2c005fd3b0cb184a77292e7e943f2b69befc3b613)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -67,6 +67,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -104,6 +122,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }

--- a/osv/malicious/npm/picasso.js/MAL-2026-11979.json
+++ b/osv/malicious/npm/picasso.js/MAL-2026-11979.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-11979",
   "published": "2026-08-04T15:48:54Z",
-  "modified": "2026-08-05T00:12:14.540397795Z",
+  "modified": "2026-08-05T04:45:20Z",
   "aliases": [
     "GHSA-6jmc-6w7f-v47v"
   ],
   "summary": "Malicious code in picasso.js (npm)",
-  "details": "npm/picasso.js is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) — the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (468d3420e8860ce0c51d3d09242e634df46a53c75a08dbd7f85d361d5485ac5b)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "npm/picasso.js is affected by the large-scale, self-propagating npm supply-chain worm of 2026-08-04 (the \"Shai-Hulud: Here We Go Again\" wave) \u2014 the same campaign that began with the compromise of the keyv and cacheable maintainer account. The listed version(s) were trojanized and republished by the worm after it reached an npm publish token belonging to a maintainer in this namespace; the payload enumerates every package a stolen token controls and republishes each with the same hook, so many packages under this scope were poisoned in the same short window. Every poisoned release adds a preinstall hook (`\"preinstall\": \"node setup.mjs\"`) that runs on a bare `npm install`, before any project code. setup.mjs downloads a standalone Bun runtime and runs a byte-identical, heavily obfuscated ~728 KB second-stage credential stealer (shipped as Math_Symbol.js / math_init.js). It harvests GitHub, npm, AWS, GCP, Azure, HashiCorp Vault and Kubernetes credentials plus generic secrets and private keys (TruffleHog-style sweep), reads CI/CD secrets and identifies build runners, then republishes further packages the stolen token can reach. Rather than a fixed command-and-control host, it exfiltrates stolen findings to attacker-created GitHub repositories (descriptions reading \"Shai-Hulud: Here We Go Again\") and over DNS. Treat any environment that installed an affected version (with install scripts enabled) as compromised: rotate and revoke all reachable credentials (npm and GitHub tokens, cloud keys, Vault/Kubernetes secrets, and CI org/repo secrets). Part of the August 2026 npm worm that poisoned 400+ packages across many organizations.\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: ghsa-malware (468d3420e8860ce0c51d3d09242e634df46a53c75a08dbd7f85d361d5485ac5b)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -67,6 +67,24 @@
             "math_init.js"
           ],
           "source": "PACKAGE_ARCHIVE"
+        },
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "stage-1 install-time loader, 11017 bytes",
+          "digests": {
+            "sha256": "fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb"
+          }
+        },
+        {
+          "paths": [
+            "package/math_init.js"
+          ],
+          "note": "stage-2 Bun-bundled payload, 727680 bytes",
+          "digests": {
+            "sha256": "9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc"
+          }
         }
       ]
     },
@@ -104,6 +122,13 @@
         "https://socket.dev"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "r-bedekar",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds reports for 15 npm packages compromised on 2026-08-04 by a self-propagating worm that ships an install-time dropper and a Bun-bundled second-stage payload. 71 versions across four maintainer organisations: `@servicetitan` (4 packages), `@or-sdk` and `@onereach` (6), `@ornikar` (2), and the Qlik picasso packages (3).

Campaign linkage is established by the payload rather than by attribution: the byte-identical 727680-byte artifact `sha256 9fc2570b7cef51c1b8df116d144d11ff4096357be7d2c4c6367cfc2509cf1bcc` appears in packages published the same day under several unrelated maintainer organisations. The same activity has been reported publicly by StepSecurity, which names it "ChainDrop", and by Socket. Neither writeup lists any of these 15 packages; both are linked from every report for correlation.

Verification performed for every version listed:

- the `preinstall` hook was read from the registry packument and matched `node setup.mjs` exactly;
- the immediately preceding release of each package was checked and carries no such hook, establishing that the files were introduced by these versions;
- the tarball for the latest affected version of each package was downloaded and its embedded payload hashed to the value above.

Two indicator notes are recorded in the reports:

- `sha256 fd3ca4007b225fdf8de7af4345a19179d5efa8c4bb9205f88cda806e5684b1eb` has been published elsewhere as a "repository loader variant". It was recovered here directly from the npm tarballs of these packages and is the npm install-time loader for this wave. The distinct loader `sha256 54dc7ea54a1317cca0e890a2770630cf7fa6c97813e0cb9d2caa93012b350668` appears in the keyv/cacheable wave of the same campaign. Both are npm loaders.
- The dropper filename is randomised per maintainer organisation, `math_init.js` in these packages and `Math_Symbol.js` in the keyv/cacheable wave, with identical payload bytes, so detections keyed to a single filename match only part of the campaign.

Reports for the keyv/cacheable and Qlik runtime packages already covered by other sources are intentionally omitted to avoid duplicate entries. At the time of filing all 15 packages were still serving a malicious `latest` tag.
