### PR TITLE
Add analysis and IoCs for the 2026-04-29 SAP package compromise

### DIFF
--- a/osv/malicious/npm/@cap-js/db-service/MAL-0000-cap-js-db-service-analysis.json
+++ b/osv/malicious/npm/@cap-js/db-service/MAL-0000-cap-js-db-service-analysis.json
@@ -1,0 +1,72 @@
+{
+  "modified": "2026-08-04T14:20:35Z",
+  "schema_version": "1.7.4",
+  "details": "Enrichment of MAL-2026-3176, which currently carries no database_specific.iocs and an attribution that the public registry record does not support.\n\nATTRIBUTION CORRECTION. MAL-2026-3176 describes this as a \"supply chain compromise of legitimate SAP packages published by threat actor \\\"cloudmtabot@gmail.com\\\" impersonating SAP toolchain maintainers\". Every surviving release of @cap-js/db-service before and after the incident \u2014 including the immediate predecessor 2.10.0 and the 2.11.0 remediation published the same day \u2014 carries _npmUser.email npm-oidc-no-reply@github.com, i.e. the project releases through GitHub Actions trusted publishing. cloudmtabot@gmail.com does not appear anywhere in this package's publish history. The evidence is consistent with a compromised legitimate release channel, which is how the accompanying advisory GHSA-pvw4-cvr4-97p8 characterises the event (\"compromised versions ... were published\"), and it is the same shape seen in later npm worm activity: the attacker publishes through credentials or a CI identity that already belong to the project. Naming the account as a threat actor attributes intent to what the record otherwise indicates is a victim, and in the three @cap-js reports it also attributes the publish to an identity absent from those packages entirely.\n\nINDICATORS (absent from MAL-2026-3176). The malicious version added two files not present in 2.10.0 and not present in 2.11.0: an install-time loader setup.mjs (4549 bytes, sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) invoked by a \"preinstall\": \"node setup.mjs\" hook, and a bundled payload execution.js (11723748 bytes, sha256 eb6eb4154b03ec73218727dc643d26f4e14dfda2438112926bb5daf37ae8bcdb). Both digests were taken from jsDelivr's per-file manifest for the exact version, which persists after the version is unpublished and is linked below as a durable public source; the npm tarball itself now 404s.\n\nFINGERPRINT REFINEMENT. MAL-2026-3176 states that all four compromised packages \"share the same fingerprint\". Only the loader is shared: setup.mjs is byte-identical (sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) across mbt@1.2.48, @cap-js/sqlite@2.2.2, @cap-js/db-service@2.10.1 and @cap-js/postgres@2.2.2. execution.js is NOT identical \u2014 it resolves to three distinct digests: 80a3d287... (mbt, 11678349 B), 6f933d00... (@cap-js/sqlite, 11729871 B), and eb6eb415... (@cap-js/db-service and @cap-js/postgres, 11723748 B, which were published in the same second and share a payload). Hash-based hunting keyed to a single execution.js digest will therefore miss three of the four packages; the loader digest is the reliable pivot.\n\nRELATED ACTIVITY. A larger npm worm campaign on 2026-08-04, publicly named \"ChainDrop\", used the identical \"preinstall\": \"node setup.mjs\" hook and the same two-file shape (a small obfuscated loader plus a large bundled payload), and likewise shipped the loader in tarballs whose package.json files allowlist does not list it \u2014 consistent with the tarball being assembled directly rather than by npm pack. Loader and payload digests, sizes and filenames all differ between the two events, so this is offered as a TTP correspondence and not as an identification of the same tooling.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@cap-js/db-service"
+      },
+      "versions": [
+        "2.10.1"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/@cap-js/db-service"
+    },
+    {
+      "type": "EVIDENCE",
+      "url": "https://data.jsdelivr.com/v1/package/npm/%40cap-js%2Fdb-service@2.10.1/flat"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-pvw4-cvr4-97p8"
+    }
+  ],
+  "credits": [
+    {
+      "name": "r-bedekar",
+      "type": "ANALYST",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "files": [
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "install-time loader added by the compromise; byte-identical across all four affected packages",
+          "digests": {
+            "sha256": "4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34"
+          }
+        },
+        {
+          "paths": [
+            "package/execution.js"
+          ],
+          "note": "bundled payload added by the compromise; digest differs per package",
+          "digests": {
+            "sha256": "eb6eb4154b03ec73218727dc643d26f4e14dfda2438112926bb5daf37ae8bcdb"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/@cap-js/postgres/MAL-0000-cap-js-postgres-analysis.json
+++ b/osv/malicious/npm/@cap-js/postgres/MAL-0000-cap-js-postgres-analysis.json
@@ -1,0 +1,72 @@
+{
+  "modified": "2026-08-04T14:20:35Z",
+  "schema_version": "1.7.4",
+  "details": "Enrichment of MAL-2026-3177, which currently carries no database_specific.iocs and an attribution that the public registry record does not support.\n\nATTRIBUTION CORRECTION. MAL-2026-3177 describes this as a \"supply chain compromise of legitimate SAP packages published by threat actor \\\"cloudmtabot@gmail.com\\\" impersonating SAP toolchain maintainers\". Every surviving release of @cap-js/postgres before and after the incident \u2014 including the immediate predecessor 2.2.1 and the 2.3.0 remediation published the same day \u2014 carries _npmUser.email npm-oidc-no-reply@github.com, i.e. the project releases through GitHub Actions trusted publishing. cloudmtabot@gmail.com does not appear anywhere in this package's publish history. The evidence is consistent with a compromised legitimate release channel, which is how the accompanying advisory GHSA-pvw4-cvr4-97p8 characterises the event (\"compromised versions ... were published\"), and it is the same shape seen in later npm worm activity: the attacker publishes through credentials or a CI identity that already belong to the project. Naming the account as a threat actor attributes intent to what the record otherwise indicates is a victim, and in the three @cap-js reports it also attributes the publish to an identity absent from those packages entirely.\n\nINDICATORS (absent from MAL-2026-3177). The malicious version added two files not present in 2.2.1 and not present in 2.3.0: an install-time loader setup.mjs (4549 bytes, sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) invoked by a \"preinstall\": \"node setup.mjs\" hook, and a bundled payload execution.js (11723748 bytes, sha256 eb6eb4154b03ec73218727dc643d26f4e14dfda2438112926bb5daf37ae8bcdb). Both digests were taken from jsDelivr's per-file manifest for the exact version, which persists after the version is unpublished and is linked below as a durable public source; the npm tarball itself now 404s.\n\nFINGERPRINT REFINEMENT. MAL-2026-3177 states that all four compromised packages \"share the same fingerprint\". Only the loader is shared: setup.mjs is byte-identical (sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) across mbt@1.2.48, @cap-js/sqlite@2.2.2, @cap-js/db-service@2.10.1 and @cap-js/postgres@2.2.2. execution.js is NOT identical \u2014 it resolves to three distinct digests: 80a3d287... (mbt, 11678349 B), 6f933d00... (@cap-js/sqlite, 11729871 B), and eb6eb415... (@cap-js/db-service and @cap-js/postgres, 11723748 B, which were published in the same second and share a payload). Hash-based hunting keyed to a single execution.js digest will therefore miss three of the four packages; the loader digest is the reliable pivot.\n\nRELATED ACTIVITY. A larger npm worm campaign on 2026-08-04, publicly named \"ChainDrop\", used the identical \"preinstall\": \"node setup.mjs\" hook and the same two-file shape (a small obfuscated loader plus a large bundled payload), and likewise shipped the loader in tarballs whose package.json files allowlist does not list it \u2014 consistent with the tarball being assembled directly rather than by npm pack. Loader and payload digests, sizes and filenames all differ between the two events, so this is offered as a TTP correspondence and not as an identification of the same tooling.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@cap-js/postgres"
+      },
+      "versions": [
+        "2.2.2"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/@cap-js/postgres"
+    },
+    {
+      "type": "EVIDENCE",
+      "url": "https://data.jsdelivr.com/v1/package/npm/%40cap-js%2Fpostgres@2.2.2/flat"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-pvw4-cvr4-97p8"
+    }
+  ],
+  "credits": [
+    {
+      "name": "r-bedekar",
+      "type": "ANALYST",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "files": [
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "install-time loader added by the compromise; byte-identical across all four affected packages",
+          "digests": {
+            "sha256": "4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34"
+          }
+        },
+        {
+          "paths": [
+            "package/execution.js"
+          ],
+          "note": "bundled payload added by the compromise; digest differs per package",
+          "digests": {
+            "sha256": "eb6eb4154b03ec73218727dc643d26f4e14dfda2438112926bb5daf37ae8bcdb"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/@cap-js/sqlite/MAL-0000-cap-js-sqlite-analysis.json
+++ b/osv/malicious/npm/@cap-js/sqlite/MAL-0000-cap-js-sqlite-analysis.json
@@ -1,0 +1,72 @@
+{
+  "modified": "2026-08-04T14:20:35Z",
+  "schema_version": "1.7.4",
+  "details": "Enrichment of MAL-2026-3178, which currently carries no database_specific.iocs and an attribution that the public registry record does not support.\n\nATTRIBUTION CORRECTION. MAL-2026-3178 describes this as a \"supply chain compromise of legitimate SAP packages published by threat actor \\\"cloudmtabot@gmail.com\\\" impersonating SAP toolchain maintainers\". Every surviving release of @cap-js/sqlite before and after the incident \u2014 including the immediate predecessor 2.2.1 and the 2.4.0 remediation published the same day \u2014 carries _npmUser.email npm-oidc-no-reply@github.com, i.e. the project releases through GitHub Actions trusted publishing. cloudmtabot@gmail.com does not appear anywhere in this package's publish history. The evidence is consistent with a compromised legitimate release channel, which is how the accompanying advisory GHSA-pvw4-cvr4-97p8 characterises the event (\"compromised versions ... were published\"), and it is the same shape seen in later npm worm activity: the attacker publishes through credentials or a CI identity that already belong to the project. Naming the account as a threat actor attributes intent to what the record otherwise indicates is a victim, and in the three @cap-js reports it also attributes the publish to an identity absent from those packages entirely.\n\nINDICATORS (absent from MAL-2026-3178). The malicious version added two files not present in 2.2.1 and not present in 2.4.0: an install-time loader setup.mjs (4549 bytes, sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) invoked by a \"preinstall\": \"node setup.mjs\" hook, and a bundled payload execution.js (11729871 bytes, sha256 6f933d00b7d05678eb43c90963a80b8947c4ae6830182f89df31da9f568fea95). Both digests were taken from jsDelivr's per-file manifest for the exact version, which persists after the version is unpublished and is linked below as a durable public source; the npm tarball itself now 404s.\n\nFINGERPRINT REFINEMENT. MAL-2026-3178 states that all four compromised packages \"share the same fingerprint\". Only the loader is shared: setup.mjs is byte-identical (sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) across mbt@1.2.48, @cap-js/sqlite@2.2.2, @cap-js/db-service@2.10.1 and @cap-js/postgres@2.2.2. execution.js is NOT identical \u2014 it resolves to three distinct digests: 80a3d287... (mbt, 11678349 B), 6f933d00... (@cap-js/sqlite, 11729871 B), and eb6eb415... (@cap-js/db-service and @cap-js/postgres, 11723748 B, which were published in the same second and share a payload). Hash-based hunting keyed to a single execution.js digest will therefore miss three of the four packages; the loader digest is the reliable pivot.\n\nRELATED ACTIVITY. A larger npm worm campaign on 2026-08-04, publicly named \"ChainDrop\", used the identical \"preinstall\": \"node setup.mjs\" hook and the same two-file shape (a small obfuscated loader plus a large bundled payload), and likewise shipped the loader in tarballs whose package.json files allowlist does not list it \u2014 consistent with the tarball being assembled directly rather than by npm pack. Loader and payload digests, sizes and filenames all differ between the two events, so this is offered as a TTP correspondence and not as an identification of the same tooling.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@cap-js/sqlite"
+      },
+      "versions": [
+        "2.2.2"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/@cap-js/sqlite"
+    },
+    {
+      "type": "EVIDENCE",
+      "url": "https://data.jsdelivr.com/v1/package/npm/%40cap-js%2Fsqlite@2.2.2/flat"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-pvw4-cvr4-97p8"
+    }
+  ],
+  "credits": [
+    {
+      "name": "r-bedekar",
+      "type": "ANALYST",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "files": [
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "install-time loader added by the compromise; byte-identical across all four affected packages",
+          "digests": {
+            "sha256": "4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34"
+          }
+        },
+        {
+          "paths": [
+            "package/execution.js"
+          ],
+          "note": "bundled payload added by the compromise; digest differs per package",
+          "digests": {
+            "sha256": "6f933d00b7d05678eb43c90963a80b8947c4ae6830182f89df31da9f568fea95"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/mbt/MAL-0000-mbt-analysis.json
+++ b/osv/malicious/npm/mbt/MAL-0000-mbt-analysis.json
@@ -1,0 +1,72 @@
+{
+  "modified": "2026-08-04T14:20:35Z",
+  "schema_version": "1.7.4",
+  "details": "Enrichment of MAL-2026-3179, which currently carries no database_specific.iocs and an attribution that the public registry record does not support.\n\nATTRIBUTION CORRECTION. MAL-2026-3179 describes this as a \"supply chain compromise of legitimate SAP packages published by threat actor \\\"cloudmtabot@gmail.com\\\" impersonating SAP toolchain maintainers\". Every surviving release of mbt before and after the incident \u2014 1.2.39 through 1.2.47, and the 1.2.49 remediation published the same day \u2014 carries _npmUser.email cloudmtabot@gmail.com. That account is therefore the package's long-standing legitimate publisher, not an outside party imitating one. The evidence is consistent with a compromised legitimate release channel, which is how the accompanying advisory GHSA-pvw4-cvr4-97p8 characterises the event (\"compromised versions ... were published\"), and it is the same shape seen in later npm worm activity: the attacker publishes through credentials or a CI identity that already belong to the project. Naming the account as a threat actor attributes intent to what the record otherwise indicates is a victim, and in the three @cap-js reports it also attributes the publish to an identity absent from those packages entirely.\n\nINDICATORS (absent from MAL-2026-3179). The malicious version added two files not present in 1.2.47 and not present in 1.2.49: an install-time loader setup.mjs (4549 bytes, sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) invoked by a \"preinstall\": \"node setup.mjs\" hook, and a bundled payload execution.js (11678349 bytes, sha256 80a3d2877813968ef847ae73b5eeeb70b9435254e74d7f07d8cf4057f0a710ac). Both digests were taken from jsDelivr's per-file manifest for the exact version, which persists after the version is unpublished and is linked below as a durable public source; the npm tarball itself now 404s.\n\nFINGERPRINT REFINEMENT. MAL-2026-3179 states that all four compromised packages \"share the same fingerprint\". Only the loader is shared: setup.mjs is byte-identical (sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34) across mbt@1.2.48, @cap-js/sqlite@2.2.2, @cap-js/db-service@2.10.1 and @cap-js/postgres@2.2.2. execution.js is NOT identical \u2014 it resolves to three distinct digests: 80a3d287... (mbt, 11678349 B), 6f933d00... (@cap-js/sqlite, 11729871 B), and eb6eb415... (@cap-js/db-service and @cap-js/postgres, 11723748 B, which were published in the same second and share a payload). Hash-based hunting keyed to a single execution.js digest will therefore miss three of the four packages; the loader digest is the reliable pivot.\n\nRELATED ACTIVITY. A larger npm worm campaign on 2026-08-04, publicly named \"ChainDrop\", used the identical \"preinstall\": \"node setup.mjs\" hook and the same two-file shape (a small obfuscated loader plus a large bundled payload), and likewise shipped the loader in tarballs whose package.json files allowlist does not list it \u2014 consistent with the tarball being assembled directly rather than by npm pack. Loader and payload digests, sizes and filenames all differ between the two events, so this is offered as a TTP correspondence and not as an identification of the same tooling.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "mbt"
+      },
+      "versions": [
+        "1.2.48"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/mbt"
+    },
+    {
+      "type": "EVIDENCE",
+      "url": "https://data.jsdelivr.com/v1/package/npm/mbt@1.2.48/flat"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-pvw4-cvr4-97p8"
+    }
+  ],
+  "credits": [
+    {
+      "name": "r-bedekar",
+      "type": "ANALYST",
+      "contact": [
+        "https://github.com/r-bedekar"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "files": [
+        {
+          "paths": [
+            "package/setup.mjs"
+          ],
+          "note": "install-time loader added by the compromise; byte-identical across all four affected packages",
+          "digests": {
+            "sha256": "4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34"
+          }
+        },
+        {
+          "paths": [
+            "package/execution.js"
+          ],
+          "note": "bundled payload added by the compromise; digest differs per package",
+          "digests": {
+            "sha256": "80a3d2877813968ef847ae73b5eeeb70b9435254e74d7f07d8cf4057f0a710ac"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Enriches the four existing reports for the 2026-04-29 SAP package compromise — `MAL-2026-3179` (mbt), `MAL-2026-3178` (@cap-js/sqlite), `MAL-2026-3176` (@cap-js/db-service) and `MAL-2026-3177` (@cap-js/postgres) — none of which currently carry `database_specific.iocs`.

Three additions.

**Indicators.** Each affected version added two files absent from both its predecessor and its remediation release: a loader `setup.mjs` (4549 bytes, `sha256 4066781fa830224c8bbcc3aa005a396657f9c8f9016f9a64ad44a9d7f5f45e34`) invoked by a `"preinstall": "node setup.mjs"` hook, and a bundled payload `execution.js` (~11.7 MB). The npm tarballs now 404, so both digests are taken from jsDelivr's per-file manifest for each exact version, which persists after unpublish; the manifest URL is linked from each report as an `EVIDENCE` reference.

**Fingerprint refinement.** The existing reports state that all four packages "share the same fingerprint". Only the loader is shared — `setup.mjs` is byte-identical across all four. `execution.js` is not: it resolves to three distinct digests, with `@cap-js/db-service` and `@cap-js/postgres` sharing one (they were published in the same second). Hunting keyed to a single `execution.js` digest misses three of the four packages; the loader digest is the reliable pivot.

**Attribution.** The existing reports describe the event as published by `threat actor "cloudmtabot@gmail.com" impersonating SAP toolchain maintainers`. The public registry record does not support this. Every surviving `mbt` release from 1.2.39 through 1.2.47, plus the 1.2.49 remediation published the same day, carries `_npmUser.email` `cloudmtabot@gmail.com` — so that account is the package's long-standing legitimate publisher rather than an outside party imitating one. Separately, `cloudmtabot@gmail.com` does not appear anywhere in the publish history of the three `@cap-js` packages; every surviving release of those, including each immediate predecessor and each same-day remediation, was published by `npm-oidc-no-reply@github.com` via GitHub Actions trusted publishing.

That reading is consistent with the accompanying advisory GHSA-pvw4-cvr4-97p8, which describes the event as "compromised versions ... were published". The correction matters because the current wording attributes intent to an account the surrounding evidence indicates was a victim, and in three of the four reports attributes the publish to an identity absent from those packages.

Each report also notes a TTP correspondence with the 2026-08-04 npm worm campaign publicly named "ChainDrop" — same `preinstall` hook string, same loader-plus-large-payload shape, and in both cases the loader ships in tarballs whose `files` allowlist does not list it, consistent with the archive being assembled directly rather than by `npm pack`. Digests, sizes and filenames differ between the two events, so this is recorded as a correspondence and explicitly not as an identification of the same tooling.
