### PR TITLE
Add OSV reports: AI-agent CLI C2 npm campaign (3 packages)

### DIFF
--- a/osv/malicious/npm/upshift-sdk/MAL-0000-upshift-sdk.json
+++ b/osv/malicious/npm/upshift-sdk/MAL-0000-upshift-sdk.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-08-16T00:00:00Z",
+  "published": "2026-08-16T00:00:00Z",
+  "summary": "Malicious code in upshift-sdk (npm)",
+  "details": "upshift-sdk exfiltrates host reconnaissance to attacker infrastructure from a postinstall script that runs on every npm install. package.json declares scripts.postinstall as an inline `node -e` program that unconditionally performs an https.get to an attacker-controlled Cloudflare Worker, sending os.hostname(), os.userInfo().username, the current working directory, the package name and version, and a timestamp. The request is wrapped in try/catch so failures stay silent and leave no obvious error. The collector is https://build-metrics-collector.cdn-ops-health.workers.dev/npm-install/. This package is part of the same campaign as the already-confirmed-malicious upshift-config, upshift-finance, and augustdigital-sdk: it uses the same command-and-control host and carries the exact same 8.20.1 version string as augustdigital-sdk@8.20.1, indicating a single actor publishing coordinated postinstall-exfiltration packages. See the related advisories referenced below.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "upshift-sdk"
+      },
+      "versions": [
+        "8.20.1"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/upshift-sdk"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://osv.dev/vulnerability/MAL-2026-13774"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://osv.dev/vulnerability/MAL-2026-13776"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://osv.dev/vulnerability/MAL-2026-13777"
+    }
+  ],
+  "credits": [
+    {
+      "name": "pkgwarden",
+      "type": "FINDER",
+      "contact": [
+        "https://pkgwarden.com"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "urls": [
+        "https://build-metrics-collector.cdn-ops-health.workers.dev/npm-install/"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds three OSV malicious-package entries for a coordinated npm campaign, reported by pkgwarden after byte-level verification of the published artifacts.

**Entries**

- `oh-aicoding-tool` (0.1.74, 0.1.76, 0.1.77): installs a persistent Claude Code `Stop` hook (via scripts/langfuse-setup.mjs, reachable from bin/cli.js) that copies langfuse_hook.py into ~/.claude/hooks/ and registers it in ~/.claude/settings.json, with a parallel Codex/OpenCode setup path. On every agent turn it reads the AI-session transcript and git repository context and exfiltrates them using hardcoded shared attacker Langfuse keys.
- `oh-aireport` (0.2.2): bundles an OpenCode plugin (.opencode/plugins/oh-ai-report.ts) whose `DEFAULT_WEBHOOK_URL` is the attacker C2, shipping session and git context plus user_id and company user_email by default with no configuration.
- `upshift-sdk` (8.20.1): package.json `scripts.postinstall` unconditionally runs an inline `node -e` https.get to an attacker Cloudflare Worker on every install, exfiltrating hostname, username, cwd, and package name/version, silenced with try/catch. Same C2 host and exact 8.20.1 version string as the already-confirmed-malicious augustdigital-sdk@8.20.1 (MAL-2026-13774), upshift-config (MAL-2026-13776), and upshift-finance (MAL-2026-13777).

**IOC hygiene**: the oh-* C2 is the attacker-operated raw IP 120.46.221.227 (fronted by metrics.openharmonyinsight.cn under the "openharmonyinsight" branding); full C2 paths are in `urls`. The upshift-sdk worker host is `*.workers.dev` shared hosting, so it is recorded only as a full URL in `urls`, never as a bare domain.

Reported by pkgwarden (https://pkgwarden.com).

---

**Related analysis:** these three packages surfaced from pkgwarden's cross-family C2 clustering of a broader coordinated campaign (~75 OSV MAL families of trojanized/impersonated AI-coding-agent CLIs). Full writeup, with the shared-infrastructure clusters and how these three were confirmed: https://pkgwarden.com/incidents/ai-agent-cli-c2-npm-august-2026/
