### PR TITLE
Remove incorrect usage of PACKAGE_ARCHIVE in IOCS.

### DIFF
--- a/osv/malicious/crates.io/arrayref/MAL-2026-14336.json
+++ b/osv/malicious/crates.io/arrayref/MAL-2026-14336.json
@@ -55,15 +55,6 @@
     "iocs": {
       "files": [
         {
-          "digests": {
-            "sha256": "25ad700976873c76af785cb99b33c48db7df8b81f21d1e9e06b3676b9a9373ae"
-          },
-          "paths": [
-            "arrayref-0.3.10.crate"
-          ],
-          "source": "PACKAGE_ARCHIVE"
-        },
-        {
           "note": "Unix second-stage binary, executed with 23.254.165.112:443 as argv[1]",
           "paths": [
             "/tmp/rust-setup"

--- a/osv/malicious/crates.io/proc_macro1/MAL-2026-14338.json
+++ b/osv/malicious/crates.io/proc_macro1/MAL-2026-14338.json
@@ -62,24 +62,6 @@
     "iocs": {
       "files": [
         {
-          "digests": {
-            "sha256": "61198155da51b838772eecf5bfaac6cbc4dcc388dccc56658fc28a8e831b34d4"
-          },
-          "paths": [
-            "proc-macro1-1.0.107.crate"
-          ],
-          "source": "PACKAGE_ARCHIVE"
-        },
-        {
-          "digests": {
-            "sha256": "b5c1b5b0763a8809a644a8f92224653f0aca623a98eecc714d27f74b80fbe436"
-          },
-          "paths": [
-            "proc-macro1-1.0.106.crate"
-          ],
-          "source": "PACKAGE_ARCHIVE"
-        },
-        {
           "note": "Unix second-stage binary, executed with 23.254.165.112:443 as argv[1]",
           "paths": [
             "/tmp/rust-setup"


### PR DESCRIPTION
PACKAGE_ARCHIVE is for artifacts *in* the archives, not the archives themselves.

A structure for these is coming soon.