### PR TITLE
report: npm/totp-utils 1.4.4 (Discord/Minecraft credential stealer)

### DIFF
--- a/osv/malicious/npm/totp-utils/MAL-0000-totp-utils.json
+++ b/osv/malicious/npm/totp-utils/MAL-0000-totp-utils.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-08-21T16:00:00Z",
+  "published": "2026-08-21T16:00:00Z",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "totp-utils"
+      },
+      "versions": [
+        "1.4.2",
+        "1.4.3",
+        "1.4.4"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "details": "On `npm install`, and whenever the exported `validateSecret()` is called, totp-utils harvests credentials and POSTs them to a hardcoded Discord webhook. It is published as a TOTP helper and keeps a working TOTP implementation as cover. It takes Discord tokens from the discord, canary, PTB and development clients and from Chrome, Edge, Brave and Opera, decrypting them with DPAPI (through a spawned PowerShell) and AES-256-GCM, and Minecraft accounts from the vanilla launcher, Lunar Client and Modrinth. The install-time trigger is a `postinstall` hook in 1.4.3 and 1.4.4; the call-time trigger is a `setImmediate(_run)` inside `validateSecret()`, present in every version including 1.4.2, so it fires even under `--ignore-scripts`. Treat any host, and any Discord or Minecraft account used on it, as compromised: remove the package, change the Discord password (which revokes the stolen tokens) and enable 2FA, rotate Minecraft and Microsoft credentials, and rotate the `.npmrc` token if it was installed in CI. All three versions were published within eight minutes on 2026-08-21, there is no release before 1.4.2, and the stated repository `github.com/totp-utils/totp-utils` returns 404.\n\nVersion 1.4.4 adds a second stage. It downloads a Fabric mod, `optimized-renderer-1.0.0.jar`, from a Discord CDN attachment and writes it into the victim's Minecraft mods folders, so it runs the next time the game launches. The mod (SHA-256 `118ad8d050ebe8d878f948cb97dc391a0f9d8734e0668dbb04eec4c17130f693`) is disguised as an FPS optimiser but is a browser stealer: it reads cookies and saved passwords from Chrome, Edge, Brave, Opera and Firefox, defeats Chrome App-Bound Encryption by launching the browser with remote debugging, decrypts with DPAPI, and also takes Discord tokens. It exfiltrates to the same webhook as the npm package. The two stages share that webhook and an embed colour, the npm account is `jeanfilsssss`, and the code comments are in French.",
+  "references": [
+    {
+      "type": "REPORT",
+      "url": "https://protet.io/disclosures/totp-utils-1.4.4"
+    },
+    {
+      "type": "EVIDENCE",
+      "url": "https://protet.io/package-analysis/npm/totp-utils/1.4.3"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/totp-utils/v/1.4.4"
+    }
+  ],
+  "credits": [
+    {
+      "name": "Robin Frehner, Protet",
+      "contact": [
+        "https://protet.io",
+        "mailto:hello@protet.io"
+      ],
+      "type": "FINDER"
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "urls": [
+        "https://discord.com/api/webhooks/1532429233769419004/VE9zx782_hy5vedls0lwNRAVA1sUGb9Q2chTdXdrcmXuNzztkeXe7Ilbt36OjWaNnTXe",
+        "https://cdn.discordapp.com/attachments/1507484731535785994/1540335670831222894/optimized-renderer-1.0.0.jar",
+        "https://api.ipify.org"
+      ],
+      "sha256": [
+        "99e67c1e69ca26f79989a98b1501c6dca4c02176364b640230f143a9c9c118b7",
+        "619f82ba4a4c02caa4aa598534b68536189ba09fc2f6d37755cde4b47d8b29cb",
+        "600511b9107e87a583882f7542cad3a504eb2ecf9b63eaaa18669c5a22f9e9ef",
+        "118ad8d050ebe8d878f948cb97dc391a0f9d8734e0668dbb04eec4c17130f693"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a report for `totp-utils` (npm), versions 1.4.2–1.4.4. All three versions were first published within eight minutes on 2026-08-21 (12:17:45Z–12:25:03Z); the version series starts at 1.4.2 with no earlier release and the stated repository `github.com/totp-utils/totp-utils` returns 404 — a purpose-built package, not a compromised library. Not present in OSV/GHSA at time of writing.

- Published as a TOTP helper (working `validateSecret`/`generateToken`/`timeRemaining` as cover); the payload is a Discord + Minecraft credential grabber that exfiltrates to a hardcoded Discord webhook.
- Fires on `npm install` via a `postinstall` hook (1.4.3, 1.4.4) and, in every version including 1.4.2, via a `setImmediate(_run)` planted inside the exported `validateSecret()` — so it fires on use even with `--ignore-scripts`.
- Steals Discord tokens (four clients + Chrome/Edge/Brave/Opera, DPAPI + AES-256-GCM) and Minecraft accounts (vanilla launcher, Lunar, Modrinth).
- 1.4.4 drops a second stage: a Fabric mod (`optimized-renderer-1.0.0.jar`, from a Discord CDN attachment) that steals cookies/passwords from Chrome/Edge/Brave/Opera/Firefox (Chrome App-Bound Encryption defeated via CDP; DPAPI) and Discord tokens, exfiltrating to the same webhook.

Full analysis: https://protet.io/disclosures/totp-utils-1.4.4
