### PR TITLE
analysis: add IoCs for MAL-2026-13631

### DIFF
--- a/osv/malicious/npm/localization-fixer/MAL-2026-13631.json
+++ b/osv/malicious/npm/localization-fixer/MAL-2026-13631.json
@@ -1,5 +1,5 @@
 {
-  "modified": "2026-08-08T00:55:08Z",
+  "modified": "2026-08-24T12:47:00Z",
   "published": "2026-08-08T00:51:34Z",
   "schema_version": "1.7.4",
   "id": "MAL-2026-13631",
@@ -74,6 +74,43 @@
     }
   ],
   "database_specific": {
+    "iocs": {
+      "ips": [
+        "13.175.176.8"
+      ],
+      "urls": [
+        "https://api.jsonbin.io/v3/b/6a718a58da38895dfeb6e2ed"
+      ],
+      "files": [
+        {
+          "paths": [
+            "src/assets/locales/fr/common.js"
+          ],
+          "note": "Backdoor file loaded at dev-server start via localizationPlugin() in vite.config.js; fetches C2 payload from jsonbin and executes via child_process.fork()",
+          "source": "PACKAGE_ARCHIVE",
+          "digests": {
+            "sha256": "a86aa35ad3d251d45ec209ac90772b9f22d915f48f07ae9677bc0384e44221f8"
+          }
+        },
+        {
+          "paths": [
+            "src/assets/locales/index.js"
+          ],
+          "note": "Locale index that imports the backdoor file",
+          "source": "PACKAGE_ARCHIVE",
+          "digests": {
+            "sha256": "c101b5fac028824c6fab25cf1811730e61ce87d18a6ae580d9540b14fdd8652d"
+          }
+        },
+        {
+          "note": "Obfuscated dropper payload retrieved from jsonbin C2 bin 6a718a58da38895dfeb6e2ed; builds IP 13.175.176.8, HTTP GET with Authentication header, base64-decodes, writes to temp file and spawns hidden process (windowsHide: true)",
+          "source": "IN_MEMORY",
+          "digests": {
+            "sha256": "93bbe975a17493d12748e41315f1caa608f8a04b91fe16327ed44701fd9c0fe7"
+          }
+        }
+      ]
+    },
     "malicious-packages-origins": [
       {
         "id": "IN-MAL-2026-017195",


### PR DESCRIPTION
This PR adds the new Indicators of Compromise (IoCs) reported in #1457 for the existing advisory `MAL-2026-13631` (ViteVenom/ChainVeil family).

### Added IoCs:
- **IP Address**: `13.175.176.8`
- **C2 URL**: `https://api.jsonbin.io/v3/b/6a718a58da38895dfeb6e2ed`
- **File path**: `src/assets/locales/fr/common.js` (Backdoor file loaded at dev-server start) - SHA-256: `a86aa35ad3d251d45ec209ac90772b9f22d915f48f07ae9677bc0384e44221f8`
- **File path**: `src/assets/locales/index.js` (Locale index file) - SHA-256: `c101b5fac028824c6fab25cf1811730e61ce87d18a6ae580d9540b14fdd8652d`
- **Dropped/In-Memory payload** - SHA-256: `93bbe975a17493d12748e41315f1caa608f8a04b91fe16327ed44701fd9c0fe7`

Closes #1457