### PR TITLE
Add additional fetch-page-assets versions to MAL-2026-6358

### DIFF
--- a/osv/malicious/npm/fetch-page-assets/MAL-2026-6358.json
+++ b/osv/malicious/npm/fetch-page-assets/MAL-2026-6358.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-6358",
   "published": "2026-06-24T01:44:29Z",
-  "modified": "2026-08-25T06:52:21.265851217Z",
+  "modified": "2026-08-28T11:18:07Z",
   "aliases": [
     "GHSA-vxq2-vhm7-7mhq"
   ],
   "summary": "Malicious code in fetch-page-assets (npm)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (b20a04be5fca12f18a1dc5791b41fb0e1b9feac721b8d12747f32b00a18cb67c)\nbabel.config.cjs contains a heavily obfuscated (obfuscator.io-style) IIFE appended after a legitimate @babel/preset-env block. It queries multiple Ethereum RPC endpoints (1rpc.io/eth, eth.drpc.org, ethereum-rpc.publicnode.com, eth-mainnet.public.blastapi.io, eth.blockscout.com/api) for transactions from the on-chain address 0xa322E5f3D311D3080e6f0121063e9aDC2490Ef1a, decodes two IPv4 C2 addresses from the transaction's destination field, fetches XOR-encrypted stage-2 payloads from those hosts at /0x/cls and /0x/ls, decrypts them with hardcoded keys, and executes the result via both eval and spawn('node', ['-e', payload], {detached:true, stdio:'ignore', windowsHide:true}).unref(). A second copy of the same dropper is smuggled as public/fonts/fa-solid-400.woff2 — the file is not a font but plain JS beginning with global.i=\"A8-*#\";global.r=require; and requiring http/https/zlib/child_process, with identical on-chain address, endpoints, and XOR keys. Requires of child_process, http, https, zlib, and url are Unicode-escaped to evade static inspection. Any consumer that installs this package and runs a Babel-using workflow (jest, build, transpile) executes attacker-controlled remote code whose current location is dynamically resolved from the Ethereum blockchain, giving the operator resilient, takedown-resistant C2 on the installer's machine.\n\n## Source: ghsa-malware (fd48ae20edf27366ea94c51e236b2dc615d3f7a8a952f414710d6e057a73b015)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "Versions 1.2.10, 1.2.11, and 1.2.12 of fetch-page-assets remain listed on the npm registry and were not included in GHSA-vxq2-vhm7-7mhq (pinned to = 1.2.9) or the later Amazon Inspector additions (1.2.13, 1.2.14). This is a PolinRider / NullReceiver compromise of a legitimate maintainer (npm: digelim / GitHub: DiogoAngelim). OpenSourceMalware's 2026-08-25 case study verified from published tarballs that 1.2.10 and 1.2.11 still ship the unchanged .vscode/tasks.json auto-run trigger (SHA-256 f5c6be4753d6613c97f1b10c4d93a5d97a8f4fb21eb13da0ed04b23a8a61c2f6) with runOn: folderOpen invoking node ./public/fonts/fa-solid-400.woff2. Version 1.2.12 restored the fake-font payload and appended an independently obfuscated NullReceiver loader to babel.config.cjs (campaign marker A8-3292-1), which executes on npm test / Babel load without VS Code. C2 is resolved from Ethereum wallet 0xa322e5f3d311d3080e6f0121063e9adc2490ef1a. See https://opensourcemalware.com/blog/polinrider-npm-case-study-dprk-attack\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (b20a04be5fca12f18a1dc5791b41fb0e1b9feac721b8d12747f32b00a18cb67c)\nbabel.config.cjs contains a heavily obfuscated (obfuscator.io-style) IIFE appended after a legitimate @babel/preset-env block. It queries multiple Ethereum RPC endpoints (1rpc.io/eth, eth.drpc.org, ethereum-rpc.publicnode.com, eth-mainnet.public.blastapi.io, eth.blockscout.com/api) for transactions from the on-chain address 0xa322E5f3D311D3080e6f0121063e9aDC2490Ef1a, decodes two IPv4 C2 addresses from the transaction's destination field, fetches XOR-encrypted stage-2 payloads from those hosts at /0x/cls and /0x/ls, decrypts them with hardcoded keys, and executes the result via both eval and spawn('node', ['-e', payload], {detached:true, stdio:'ignore', windowsHide:true}).unref(). A second copy of the same dropper is smuggled as public/fonts/fa-solid-400.woff2 — the file is not a font but plain JS beginning with global.i=\"A8-*#\";global.r=require; and requiring http/https/zlib/child_process, with identical on-chain address, endpoints, and XOR keys. Requires of child_process, http, https, zlib, and url are Unicode-escaped to evade static inspection. Any consumer that installs this package and runs a Babel-using workflow (jest, build, transpile) executes attacker-controlled remote code whose current location is dynamically resolved from the Ethereum blockchain, giving the operator resilient, takedown-resistant C2 on the installer's machine.\n\n## Source: ghsa-malware (fd48ae20edf27366ea94c51e236b2dc615d3f7a8a952f414710d6e057a73b015)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -17,7 +17,10 @@
       "versions": [
         "1.2.9",
         "1.2.14",
-        "1.2.13"
+        "1.2.13",
+        "1.2.10",
+        "1.2.11",
+        "1.2.12"
       ],
       "database_specific": {
         "cwes": [
@@ -70,6 +73,22 @@
     {
       "type": "PACKAGE",
       "url": "https://www.npmjs.com/package/fetch-page-assets/v/1.2.13"
+    },
+    {
+      "type": "WEB",
+      "url": "https://opensourcemalware.com/blog/polinrider-npm-case-study-dprk-attack"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/fetch-page-assets/v/1.2.10"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/fetch-page-assets/v/1.2.11"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/fetch-page-assets/v/1.2.12"
     }
   ],
   "database_specific": {
@@ -113,6 +132,20 @@
         "inspector-research@amazon.com"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "OpenSourceMalware",
+      "type": "FINDER",
+      "contact": [
+        "https://opensourcemalware.com"
+      ]
+    },
+    {
+      "name": "Echo",
+      "type": "FINDER",
+      "contact": [
+        "https://www.echo.ai"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Updates the existing `fetch-page-assets` advisory (`MAL-2026-6358`) with three still-listed npm versions that were omitted from GHSA-vxq2-vhm7-7mhq (pinned to `= 1.2.9`) and from the later Amazon Inspector additions (`1.2.13`, `1.2.14`).

OpenSourceMalware's [PolinRider case study](https://opensourcemalware.com/blog/polinrider-npm-case-study-dprk-attack) verified from published tarballs that `1.2.10` and `1.2.11` still ship the `.vscode/tasks.json` auto-run trigger, and that `1.2.12` restored the fake-font payload plus an independently obfuscated NullReceiver loader in `babel.config.cjs`.

This PR also adds **OpenSourceMalware** and **Echo** as additional `FINDER` credits. Pre-existing source details, origins, and Inspector indicators are preserved unchanged.

## Updated advisory

- `fetch-page-assets`: `MAL-2026-6358` — added versions `1.2.10`, `1.2.11`, `1.2.12`

## Validation

- Parsed the modified JSON file successfully with `json.loads`.
- Did not edit below the per-source details marker.
- Did not add a `malicious-packages-origins` entry.
