### PR TITLE
Add additional html-to-gutenberg versions to MAL-2026-6359

### DIFF
--- a/osv/malicious/npm/html-to-gutenberg/MAL-2026-6359.json
+++ b/osv/malicious/npm/html-to-gutenberg/MAL-2026-6359.json
@@ -2,12 +2,12 @@
   "schema_version": "1.7.4",
   "id": "MAL-2026-6359",
   "published": "2026-06-24T01:51:00Z",
-  "modified": "2026-08-05T07:08:53.076708886Z",
+  "modified": "2026-08-28T11:18:07Z",
   "aliases": [
     "GHSA-2gqj-wrf5-35w8"
   ],
   "summary": "Malicious code in html-to-gutenberg (npm)",
-  "details": "\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (3edf079490239b2b4c592ce4b7094c8089596437c15a73972ebd8282484a5273)\nAnalysis of html-to-gutenberg@4.2.14 surfaced no a static rule matches and no traced behaviors indicating credential access, install-time remote code execution, silent relay of caller data, backdoor persistence, or dependency-tree hijack. No attacker-controlled network destinations, obfuscated payloads, or lifecycle-script droppers were identified in the package contents.\n\n## Source: ghsa-malware (6381496c1a275836b5d3c11ca7f141ad32f84b5263450bf5cb3c9a91289dcd1d)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
+  "details": "The same compromised maintainer published html-to-gutenberg 4.2.12 and 4.2.13 on 2026-07-15 (same window as fetch-page-assets 1.2.10/1.2.11) and 4.2.15/4.2.16 on 2026-08-23 (same account-wide force-push burst that shipped fetch-page-assets 1.2.13/1.2.14). OpenSourceMalware documented that the html-to-gutenberg GitHub repository was re-infected in that August burst with payload blob 0272b9f2b1a0dda93baebf3bae505e22959a5464, and that .vscode/tasks.json (blob 5e226620d2e360205cc8634e3c581a008d382561, SHA-256 f5c6be4753d6613c97f1b10c4d93a5d97a8f4fb21eb13da0ed04b23a8a61c2f6) was present on main of all seven of the maintainer's non-archived repos as of 2026-08-24. These four npm versions are still listed on the registry. 4.2.14 is already listed; Amazon Inspector reported no malware in that tarball, so this update does not change 4.2.14. See https://opensourcemalware.com/blog/polinrider-npm-case-study-dprk-attack\n\n---\n_-= Per source details. Do not edit below this line.=-_\n\n## Source: amazon-inspector (3edf079490239b2b4c592ce4b7094c8089596437c15a73972ebd8282484a5273)\nAnalysis of html-to-gutenberg@4.2.14 surfaced no a static rule matches and no traced behaviors indicating credential access, install-time remote code execution, silent relay of caller data, backdoor persistence, or dependency-tree hijack. No attacker-controlled network destinations, obfuscated payloads, or lifecycle-script droppers were identified in the package contents.\n\n## Source: ghsa-malware (6381496c1a275836b5d3c11ca7f141ad32f84b5263450bf5cb3c9a91289dcd1d)\nAny computer that has this package installed or running should be considered fully compromised. All secrets and keys stored on that computer should be rotated immediately from a different computer. The package should be removed, but as full control of the computer may have been given to an outside entity, there is no guarantee that removing the package will remove all malicious software resulting from installing it.\n",
   "affected": [
     {
       "package": {
@@ -16,7 +16,11 @@
       },
       "versions": [
         "4.2.11",
-        "4.2.14"
+        "4.2.14",
+        "4.2.12",
+        "4.2.13",
+        "4.2.15",
+        "4.2.16"
       ],
       "database_specific": {
         "cwes": [
@@ -58,6 +62,26 @@
     {
       "type": "PACKAGE",
       "url": "https://www.npmjs.com/package/html-to-gutenberg/v/4.2.14"
+    },
+    {
+      "type": "WEB",
+      "url": "https://opensourcemalware.com/blog/polinrider-npm-case-study-dprk-attack"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/html-to-gutenberg/v/4.2.12"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/html-to-gutenberg/v/4.2.13"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/html-to-gutenberg/v/4.2.15"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/html-to-gutenberg/v/4.2.16"
     }
   ],
   "database_specific": {
@@ -102,6 +126,20 @@
         "inspector-research@amazon.com"
       ],
       "type": "FINDER"
+    },
+    {
+      "name": "OpenSourceMalware",
+      "type": "FINDER",
+      "contact": [
+        "https://opensourcemalware.com"
+      ]
+    },
+    {
+      "name": "Echo",
+      "type": "FINDER",
+      "contact": [
+        "https://www.echo.ai"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Updates the existing `html-to-gutenberg` advisory (`MAL-2026-6359`) with four still-listed npm versions from the same compromised maintainer as `fetch-page-assets`.

`4.2.12` and `4.2.13` were published on 2026-07-15 (same window as `fetch-page-assets` `1.2.10`/`1.2.11`). `4.2.15` and `4.2.16` were published on 2026-08-23 (same account-wide burst that shipped `fetch-page-assets` `1.2.13`/`1.2.14`). OpenSourceMalware's [PolinRider case study](https://opensourcemalware.com/blog/polinrider-npm-case-study-dprk-attack) documented that the `html-to-gutenberg` GitHub repository was re-infected in that August burst.

`4.2.14` is already listed; Amazon Inspector reported no malware in that tarball, so this update does not change it.

This PR also adds **OpenSourceMalware** and **Echo** as additional `FINDER` credits. Pre-existing source details, origins, and Inspector indicators are preserved unchanged.

## Updated advisory

- `html-to-gutenberg`: `MAL-2026-6359` — added versions `4.2.12`, `4.2.13`, `4.2.15`, `4.2.16`

## Validation

- Parsed the modified JSON file successfully with `json.loads`.
- Did not edit below the per-source details marker.
- Did not add a `malicious-packages-origins` entry.
