### PR TITLE
Add OSV reports for pr0t31n dependency-confusion campaign - npm (3 packages)

### DIFF
--- a/osv/malicious/npm/@caliperx2/components/MAL-0000-components.json
+++ b/osv/malicious/npm/@caliperx2/components/MAL-0000-components.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-09-07T00:00:00Z",
+  "published": "2026-09-07T00:00:00Z",
+  "details": "This package is malicious. It is not a real library. An attacker put it on the public npm registry. The package name is a copy of a private, internal package name. This is a dependency confusion attack. A build that gets the name from public npm installs this package in place of the real one.\n\nThe package.json has a `preinstall` script. npm runs this script during install. The script file is `preinstall.js`. It runs before a person can read the code.\n\nThe script collects data about the host. It reads the host name, the user name, the current directory, the install directory, the package name, the package version, the operating system, the Node.js version, and the npm user-agent text.\n\nThe script sends this data to remote servers. It uses three ways. First, it makes a DNS request to a subdomain of `oast.online`. It writes the token, the package name, the host name, and the user name into the DNS name as hex text. Second, it sends an HTTPS POST with the data as JSON to the same `oast.online` host. If HTTPS fails, it uses plain HTTP. Third, it sends an HTTP POST with the same JSON to a fixed IP address, 5.189.159.252. The beacon uses a fixed token, `caliperx2-4d5f8e2a9b1c`.\n\nThe code comments say this is authorized bug-bounty research. The behavior is still an unwanted install-time beacon. It sends host data to attacker-controlled servers without consent. All versions are malicious. Treat every host that installed this package as exposed. Remove the package. Look for DNS and HTTP traffic to the listed servers.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "@caliperx2/components"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/@caliperx2/components"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "dae7n4pijsh1ahi9684gu8get3kaiefc9.oast.online"
+      ],
+      "ips": [
+        "5.189.159.252"
+      ],
+      "urls": [
+        "https://dae7n4pijsh1ahi9684gu8get3kaiefc9.oast.online/beacon/caliperx2-4d5f8e2a9b1c",
+        "http://5.189.159.252/beacon/caliperx2-4d5f8e2a9b1c"
+      ],
+      "files": [
+        {
+          "source": "PACKAGE_ARCHIVE",
+          "paths": [
+            "preinstall.js"
+          ],
+          "note": "Preinstall beacon. It collects host data and sends it to attacker servers over DNS and HTTP(S).",
+          "digests": {
+            "sha256": "0a8f7a045bc8efe836751429f6c0d3936a7b6f98ddd4d3a6134641f6ca0e8f09"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/b2b-frontend-external-library/MAL-0000-b2b-frontend-external-library.json
+++ b/osv/malicious/npm/b2b-frontend-external-library/MAL-0000-b2b-frontend-external-library.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-09-07T00:00:00Z",
+  "published": "2026-09-07T00:00:00Z",
+  "details": "This package is malicious. It is not a real library. An attacker put it on the public npm registry. The package name is a copy of a private, internal package name. This is a dependency confusion attack. A build that gets the name from public npm installs this package in place of the real one.\n\nThe package.json has a `preinstall` script. npm runs this script during install. The script file is `preinstall.js`. It runs before a person can read the code.\n\nThe script collects data about the host. It reads the host name, the user name, the current directory, the install directory, the package name, the package version, the operating system, the Node.js version, and the npm user-agent text.\n\nThe script sends this data to remote servers. It uses three ways. First, it makes a DNS request to a subdomain of `oast.online`. It writes the token, the package name, the host name, and the user name into the DNS name as hex text. Second, it sends an HTTPS POST with the data as JSON to the same `oast.online` host. If HTTPS fails, it uses plain HTTP. Third, it sends an HTTP POST with the same JSON to a fixed IP address, 5.189.159.252. The beacon uses a fixed token, `swisscom-oce-3b9f1c7a2e`.\n\nThe `index.js` file does nothing. It is a placeholder. The code comments say this is authorized bug-bounty research. The behavior is still an unwanted install-time beacon. It sends host data to attacker-controlled servers without consent. All versions are malicious. Treat every host that installed this package as exposed. Remove the package. Look for DNS and HTTP traffic to the listed servers.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "b2b-frontend-external-library"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/b2b-frontend-external-library"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "dae7n4pijsh1ahi9684gu8get3kaiefc9.oast.online"
+      ],
+      "ips": [
+        "5.189.159.252"
+      ],
+      "urls": [
+        "https://dae7n4pijsh1ahi9684gu8get3kaiefc9.oast.online/beacon/swisscom-oce-3b9f1c7a2e",
+        "http://5.189.159.252/beacon/swisscom-oce-3b9f1c7a2e"
+      ],
+      "files": [
+        {
+          "source": "PACKAGE_ARCHIVE",
+          "paths": [
+            "preinstall.js"
+          ],
+          "note": "Preinstall beacon. It collects host data and sends it to attacker servers over DNS and HTTP(S).",
+          "digests": {
+            "sha256": "8f962a246826aaa6f7bd9db43ad0f13a51488058b451c82768f69913191ebfcb"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/osv/malicious/npm/omni-channel-configurator-wireline-frontend/MAL-0000-omni-channel-configurator-wireline-frontend.json
+++ b/osv/malicious/npm/omni-channel-configurator-wireline-frontend/MAL-0000-omni-channel-configurator-wireline-frontend.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-09-07T00:00:00Z",
+  "published": "2026-09-07T00:00:00Z",
+  "details": "This package is malicious. It is not a real library. An attacker put it on the public npm registry. The package name is a copy of a private, internal package name. This is a dependency confusion attack. A build that gets the name from public npm installs this package in place of the real one.\n\nThe package.json has a `preinstall` script. npm runs this script during install. The script file is `preinstall.js`. It runs before a person can read the code.\n\nThe script collects data about the host. It reads the host name, the user name, the current directory, the install directory, the package name, the package version, the operating system, the Node.js version, and the npm user-agent text.\n\nThe script sends this data to remote servers. It uses three ways. First, it makes a DNS request to a subdomain of `oast.online`. It writes the token, the package name, the host name, and the user name into the DNS name as hex text. Second, it sends an HTTPS POST with the data as JSON to the same `oast.online` host. If HTTPS fails, it uses plain HTTP. Third, it sends an HTTP POST with the same JSON to a fixed IP address, 5.189.159.252. The beacon uses a fixed token, `swisscom-oce-3b9f1c7a2e`.\n\nThe `index.js` file does nothing. It is a placeholder. The code comments say this is authorized bug-bounty research. The behavior is still an unwanted install-time beacon. It sends host data to attacker-controlled servers without consent. All versions are malicious. Treat every host that installed this package as exposed. Remove the package. Look for DNS and HTTP traffic to the listed servers.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "omni-channel-configurator-wireline-frontend"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "description": "The product contains code that appears to be malicious in nature.",
+            "name": "Embedded Malicious Code"
+          }
+        ]
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/omni-channel-configurator-wireline-frontend"
+    }
+  ],
+  "credits": [
+    {
+      "name": "SafeDep",
+      "type": "FINDER",
+      "contact": [
+        "https://safedep.io"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "dae7n4pijsh1ahi9684gu8get3kaiefc9.oast.online"
+      ],
+      "ips": [
+        "5.189.159.252"
+      ],
+      "urls": [
+        "https://dae7n4pijsh1ahi9684gu8get3kaiefc9.oast.online/beacon/swisscom-oce-3b9f1c7a2e",
+        "http://5.189.159.252/beacon/swisscom-oce-3b9f1c7a2e"
+      ],
+      "files": [
+        {
+          "source": "PACKAGE_ARCHIVE",
+          "paths": [
+            "preinstall.js"
+          ],
+          "note": "Preinstall beacon. It collects host data and sends it to attacker servers over DNS and HTTP(S).",
+          "digests": {
+            "sha256": "8f962a246826aaa6f7bd9db43ad0f13a51488058b451c82768f69913191ebfcb"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
These reports cover three npm packages from the user `pr0t31n`. The packages are a dependency-confusion attack. Each name copies a private, internal package name.

Each package has a `preinstall` script. npm runs the script on install. The script collects host data. It reads the host name, the user name, the file paths, and the OS, Node.js, and npm versions. It then sends the data to remote servers. It uses one DNS request and two HTTP(S) POST requests.

The code comments call this bug-bounty research. The behavior is still an unwanted install-time beacon. All versions are malicious.

Four more packages from the same user already have MAL IDs. 

- `omni-channel-oid-frontend` — MAL-2026-15939
- `oce-configurator-wireless-frontend` — MAL-2026-15940
- `ocfe-tv-subscription-center-web` — MAL-2026-15941
- `omni-channel-order-frontend` — MAL-2026-15942

