### PR TITLE
Add malicious PyPI package tsshare (Tushare impersonation; covert token + fingerprint exfil)

### DIFF
--- a/osv/malicious/pypi/tsshare/MAL-0000-tsshare.json
+++ b/osv/malicious/pypi/tsshare/MAL-0000-tsshare.json
@@ -41,68 +41,86 @@
       "ips": [
         "47.112.191.75"
       ],
-      "urls": [
-        "https://47.112.191.75"
-      ],
       "files": [
-        "tsshare/client.py"
-      ],
-      "hashes": [
         {
-          "version": "1.0.5",
-          "sdist": "tsshare-1.0.5.tar.gz",
-          "sdist_sha256": "2be7c0164bb33e34af94f0b345ed0bd1ea34547e99cf698c977d6706567701a5",
-          "file": "tsshare/client.py",
-          "file_sha256": "29453a1e5d67a98d313736026116b556b19f984ba03857c269eca0f06a543873"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.5: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "29453a1e5d67a98d313736026116b556b19f984ba03857c269eca0f06a543873"
+          }
         },
         {
-          "version": "1.0.6",
-          "sdist": "tsshare-1.0.6.tar.gz",
-          "sdist_sha256": "b76a9a045bd07283153445798f8558a8e3b3c0a27386c78da65952edb68e2a69",
-          "file": "tsshare/client.py",
-          "file_sha256": "4de73f9c46c43669da913d746257cd96c6a5b6f58775b459342764c8c46e5405"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.6: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "4de73f9c46c43669da913d746257cd96c6a5b6f58775b459342764c8c46e5405"
+          }
         },
         {
-          "version": "1.0.9",
-          "sdist": "tsshare-1.0.9.tar.gz",
-          "sdist_sha256": "e11e067150ebad064efc6758b0a1b7b208d1cf255db76ee8e5cd842dd2c60991",
-          "file": "tsshare/client.py",
-          "file_sha256": "189a4bc67c4c986ea15be023c27ae1661e56295f249c4a450a8922a5a176532d"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.9: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "189a4bc67c4c986ea15be023c27ae1661e56295f249c4a450a8922a5a176532d"
+          }
         },
         {
-          "version": "1.0.14",
-          "sdist": "tsshare-1.0.14.tar.gz",
-          "sdist_sha256": "4581809610af5537a1d713a8181a495faffe67d5c5adfb3ef410dbc2f0b15ebd",
-          "file": "tsshare/client.py",
-          "file_sha256": "0851ecfe02c43e5da464d81932166a22e47d205a6cda1a608c3e1cdead9052f6"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.14: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "0851ecfe02c43e5da464d81932166a22e47d205a6cda1a608c3e1cdead9052f6"
+          }
         },
         {
-          "version": "1.0.15",
-          "sdist": "tsshare-1.0.15.tar.gz",
-          "sdist_sha256": "8bf8cd224f6614e0bbf86cd5e80b8a5f1ad738b69c0da61e40896c7983b93278",
-          "file": "tsshare/client.py",
-          "file_sha256": "19ca5c52f32e85095f5398312f0033dd7584f3f5a49ebce419e91f4df224e41a"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.15: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "19ca5c52f32e85095f5398312f0033dd7584f3f5a49ebce419e91f4df224e41a"
+          }
         },
         {
-          "version": "1.0.16",
-          "sdist": "tsshare-1.0.16.tar.gz",
-          "sdist_sha256": "7afc0bf6a038868bca38a79a1abc0ab9dfb1735a5a57422a9ca93ea8c4726037",
-          "file": "tsshare/client.py",
-          "file_sha256": "18b9f8fde4828197ade30950516d5aafae1bb75cf9404db8bab932bfb883fdd1"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.16: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "18b9f8fde4828197ade30950516d5aafae1bb75cf9404db8bab932bfb883fdd1"
+          }
         },
         {
-          "version": "1.0.18",
-          "sdist": "tsshare-1.0.18.tar.gz",
-          "sdist_sha256": "a6df29fcc725177c15354c5340aa6704df03113de699b55f6e8a21c7e5a068da",
-          "file": "tsshare/client.py",
-          "file_sha256": "0371d8654341e50e0e8f4068323bef48e8c0271cd64d59de27a71074a9846b9b"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.18: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "0371d8654341e50e0e8f4068323bef48e8c0271cd64d59de27a71074a9846b9b"
+          }
         },
         {
-          "version": "1.0.19",
-          "sdist": "tsshare-1.0.19.tar.gz",
-          "sdist_sha256": "4971759a098b6028da02b53261f8005ce4159f4695418374e20be0c9e8672333",
-          "file": "tsshare/client.py",
-          "file_sha256": "9323e40c5a183d269df723f5f0a018a3cc7c45c9267f514871dd4c583774e204"
+          "paths": [
+            "tsshare/client.py"
+          ],
+          "source": "PACKAGE_ARCHIVE",
+          "note": "tsshare 1.0.19: Tushare-impersonating market-data client. Base64-decodes its default endpoint to the raw IP 47.112.191.75 (Alibaba CN), builds a cross-platform hardware fingerprint (Win32_DiskDrive serial / macOS Hardware UUID / Linux /etc/machine-id), and sends the user's Tushare auth_code token to that hidden endpoint on API use.",
+          "digests": {
+            "sha256": "9323e40c5a183d269df723f5f0a018a3cc7c45c9267f514871dd4c583774e204"
+          }
         }
       ]
     }

--- a/osv/malicious/pypi/tsshare/MAL-0000-tsshare.json
+++ b/osv/malicious/pypi/tsshare/MAL-0000-tsshare.json
@@ -1,0 +1,52 @@
+{
+  "modified": "2026-09-07T00:00:00Z",
+  "published": "2026-09-07T00:00:00Z",
+  "schema_version": "1.6.0",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "PyPI",
+        "name": "tsshare"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "details": "The PyPI package `tsshare` is malicious. It impersonates the popular Chinese market-data library `tushare` (confusable name; its docstrings advertise compatibility with `Tushare pro_bar` and it ships backward-compat aliases `MyShareClient`/`MyShareError`). Its default API endpoint is deliberately concealed: `tsshare/client.py` base64-decodes `aHR0cHM6Ly80Ny4xMTIuMTkxLjc1` to the hardcoded raw IP `https://47.112.191.75` (Alibaba Cloud, China) instead of a named domain - legitimate clients do not hide their own base URL in base64. When the API is used, the client (a) builds a persistent cross-platform hardware fingerprint - Windows disk-drive serial via PowerShell `Win32_DiskDrive`, macOS `Hardware UUID` via `system_profiler`, Linux `/etc/machine-id` - and (b) routes the request, carrying the user's Tushare `auth_code` token, to that hidden endpoint. The operator therefore receives the user's paid API token alongside a stable machine identifier. There is no install-time hook (no malicious `setup.py`/postinstall); exfiltration occurs on API use, so it evades install-time scanners. All eight versions in our corpus (1.0.5, 1.0.6, 1.0.9, 1.0.14, 1.0.15, 1.0.16, 1.0.18, 1.0.19) carry the identical hidden endpoint and fingerprinting from the earliest version - the entire package is malicious. Detected and classified independently by codelake Research (not present in OSV or GHSA at report time).",
+  "credits": [
+    {
+      "name": "codelake Research",
+      "type": "FINDER",
+      "contact": [
+        "https://research.codelake.dev"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://research.codelake.dev/advisories/clr-2026-3053-tsshare"
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "ips": [
+        "47.112.191.75"
+      ],
+      "urls": [
+        "https://47.112.191.75"
+      ],
+      "files": [
+        "tsshare/client.py"
+      ]
+    }
+  }
+}

--- a/osv/malicious/pypi/tsshare/MAL-0000-tsshare.json
+++ b/osv/malicious/pypi/tsshare/MAL-0000-tsshare.json
@@ -46,6 +46,64 @@
       ],
       "files": [
         "tsshare/client.py"
+      ],
+      "hashes": [
+        {
+          "version": "1.0.5",
+          "sdist": "tsshare-1.0.5.tar.gz",
+          "sdist_sha256": "2be7c0164bb33e34af94f0b345ed0bd1ea34547e99cf698c977d6706567701a5",
+          "file": "tsshare/client.py",
+          "file_sha256": "29453a1e5d67a98d313736026116b556b19f984ba03857c269eca0f06a543873"
+        },
+        {
+          "version": "1.0.6",
+          "sdist": "tsshare-1.0.6.tar.gz",
+          "sdist_sha256": "b76a9a045bd07283153445798f8558a8e3b3c0a27386c78da65952edb68e2a69",
+          "file": "tsshare/client.py",
+          "file_sha256": "4de73f9c46c43669da913d746257cd96c6a5b6f58775b459342764c8c46e5405"
+        },
+        {
+          "version": "1.0.9",
+          "sdist": "tsshare-1.0.9.tar.gz",
+          "sdist_sha256": "e11e067150ebad064efc6758b0a1b7b208d1cf255db76ee8e5cd842dd2c60991",
+          "file": "tsshare/client.py",
+          "file_sha256": "189a4bc67c4c986ea15be023c27ae1661e56295f249c4a450a8922a5a176532d"
+        },
+        {
+          "version": "1.0.14",
+          "sdist": "tsshare-1.0.14.tar.gz",
+          "sdist_sha256": "4581809610af5537a1d713a8181a495faffe67d5c5adfb3ef410dbc2f0b15ebd",
+          "file": "tsshare/client.py",
+          "file_sha256": "0851ecfe02c43e5da464d81932166a22e47d205a6cda1a608c3e1cdead9052f6"
+        },
+        {
+          "version": "1.0.15",
+          "sdist": "tsshare-1.0.15.tar.gz",
+          "sdist_sha256": "8bf8cd224f6614e0bbf86cd5e80b8a5f1ad738b69c0da61e40896c7983b93278",
+          "file": "tsshare/client.py",
+          "file_sha256": "19ca5c52f32e85095f5398312f0033dd7584f3f5a49ebce419e91f4df224e41a"
+        },
+        {
+          "version": "1.0.16",
+          "sdist": "tsshare-1.0.16.tar.gz",
+          "sdist_sha256": "7afc0bf6a038868bca38a79a1abc0ab9dfb1735a5a57422a9ca93ea8c4726037",
+          "file": "tsshare/client.py",
+          "file_sha256": "18b9f8fde4828197ade30950516d5aafae1bb75cf9404db8bab932bfb883fdd1"
+        },
+        {
+          "version": "1.0.18",
+          "sdist": "tsshare-1.0.18.tar.gz",
+          "sdist_sha256": "a6df29fcc725177c15354c5340aa6704df03113de699b55f6e8a21c7e5a068da",
+          "file": "tsshare/client.py",
+          "file_sha256": "0371d8654341e50e0e8f4068323bef48e8c0271cd64d59de27a71074a9846b9b"
+        },
+        {
+          "version": "1.0.19",
+          "sdist": "tsshare-1.0.19.tar.gz",
+          "sdist_sha256": "4971759a098b6028da02b53261f8005ce4159f4695418374e20be0c9e8672333",
+          "file": "tsshare/client.py",
+          "file_sha256": "9323e40c5a183d269df723f5f0a018a3cc7c45c9267f514871dd4c583774e204"
+        }
       ]
     }
   }


### PR DESCRIPTION
Adds the malicious PyPI package `tsshare`. Not previously in OSV or GHSA — **codelake first-catch** (the same package is independently flagged in #1496).

`tsshare` impersonates the popular Chinese market-data library **Tushare** — its docstrings advertise compatibility with `Tushare pro_bar` and it ships `MyShareClient`/`MyShareError` aliases (confusable name). Its default API endpoint is **deliberately concealed**: `tsshare/client.py` base64-decodes `aHR0cHM6Ly80Ny4xMTIuMTkxLjc1` to the hardcoded raw IP `https://47.112.191.75` (Alibaba Cloud, China). Legitimate clients do not base64-encode their own base URL.

On API use the client builds a persistent cross-platform **hardware fingerprint** (Windows `Win32_DiskDrive` serial via PowerShell, macOS `Hardware UUID` via `system_profiler`, Linux `/etc/machine-id`) and routes the request — carrying the user's Tushare `auth_code` token — to that hidden endpoint. There is **no install-time hook**; exfiltration occurs on API use, so it evades install-time scanners.

All eight versions in our corpus (1.0.5 → 1.0.19) carry the identical hidden endpoint and fingerprinting from the earliest version, so the entire package is malicious (`introduced: 0`).

**Advisory:** https://research.codelake.dev/advisories/clr-2026-3053-tsshare

Analysis method: static code + dataflow review of the published PyPI sdists; no execution, no live callback.
