### PR TITLE
Add malicious npm package cat-sis2go-utils (dependency confusion, install-time beacon)

### DIFF
--- a/osv/malicious/npm/cat-sis2go-utils/MAL-0000-cat-sis2go-utils.json
+++ b/osv/malicious/npm/cat-sis2go-utils/MAL-0000-cat-sis2go-utils.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-09-07T15:51:49Z",
+  "details": "cat-sis2go-utils was published to the public npm registry at versions 99.0.0 and 99.1.0. The package contains no library functionality: the published tarballs hold three files, and index.js is 87 bytes that export a stub object whose own note reads \"cat-sis2go-utils dependency-confusion PoC shim\". The only executable content is the install-time payload. The name combines the `cat-` prefix with `sis2go`, matching Caterpillar's SIS2GO product (the mobile companion to Cat SIS 2.0, Caterpillar's Service Information System), and the inflated 99.x versions are consistent with a dependency-confusion attempt, in which a public package outranks a private package of the same name during resolution. The existence of a private package under this name could not be verified from public data.\n\npackage.json declares both a `preinstall` and a `postinstall` script, each running `node scripts/run.js`, so the payload executes twice during `npm install`, before any application code runs. scripts/run.js makes two out-of-band callbacks:\n\n1. A DNS lookup of `d22d92dc-84e5-4b58-8cd6-75bf1ac452c7.dnshook.site`, which signals the install to a third-party DNS collector even from hosts with no outbound HTTP path.\n2. An HTTPS POST to `https://webhook.site/d22d92dc-84e5-4b58-8cd6-75bf1ac452c7`.\n\nThe two versions differ in what that POST carries. 99.0.0 sends only `{\"marker\":\"ping\"}`. 99.1.0, published four minutes later, collects and transmits `os.userInfo().username` (falling back to `process.env.USER` or `USERNAME`) together with `os.hostname()`. The installing host's login name and hostname are therefore sent to a third-party collector at install time.\n\nThe package self-identifies as a proof of concept: the description reads \"SIS2GO utils (dependency-confusion PoC)\" and the author field carries a wearehackerone.com address. The beacon nonetheless fires on every install that resolves this package, regardless of who performs it. The publishing account has no other packages, and the npm download API reports 299 downloads on the publication day (2026-09-05) and 65 the following day.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "cat-sis2go-utils"
+      },
+      "versions": [
+        "99.0.0",
+        "99.1.0"
+      ],
+      "database_specific": {
+        "cwes": [
+          {
+            "cweId": "CWE-506",
+            "name": "Embedded Malicious Code",
+            "description": "The product contains code that appears to be malicious in nature."
+          }
+        ],
+        "indicators": {
+          "evidence_files": [
+            {
+              "path": "index.js",
+              "sha256": "0897440200959313ca1e8735d8d1524f70a0bddcde66778ecd46c0bb4981981f"
+            },
+            {
+              "path": "package.json",
+              "sha256": "91b460b9612ce51d74cb187bcf1793bd115255b117e5ca5858075c3a90b6b2b9"
+            },
+            {
+              "path": "scripts/run.js",
+              "sha256": "b0ccdc7aaba664b0b4da3f317d06789d4cda2473f50c37a1c13264389130d6d7"
+            },
+            {
+              "path": "package.json",
+              "sha256": "0e3e6be9b193ff4b3e6bd60bc0bfe1d97b9f1c2d73d8fa2d731597b00b8501c1"
+            },
+            {
+              "path": "scripts/run.js",
+              "sha256": "0b598419ad8ba34a16ac19961d91208266d100dfed2598d298fbf9d5cb7eea2b"
+            }
+          ],
+          "package_integrity": [
+            {
+              "filename": "cat-sis2go-utils-99.0.0.tgz",
+              "hashes": {
+                "sha1": "82d98820e1479832ac3c34a1c11a16c05136d710",
+                "sha256": "dbbccd00d8b15b4a2cfdda703a7239fafb19bcc85d776e79d1dfea8bf1e6ade7",
+                "sha512_sri": "sha512-6N1ngpFVvlJMB74DIdv52BvWFUSU0w0Baq8LiF0YKCNZHefP++EWfZIx+W/SYTNMZpDK3nqtoNvx2nMvOqW9OA=="
+              }
+            },
+            {
+              "filename": "cat-sis2go-utils-99.1.0.tgz",
+              "hashes": {
+                "sha1": "49e87faf015f6773e543b29044c7ee396b20c85f",
+                "sha256": "84700e40dc212a3bb7e866f73f1f9882548f1a73e2f99292149b97fe01823ef4",
+                "sha512_sri": "sha512-wx8JSI0n1stzrdeP3eUD9piuGQKVMbrB4/ZV/Ez1IaNUT+4EBXSmejvY64wx7xd9dQ43x60XN4i3msVUW3dr6A=="
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/cat-sis2go-utils/v/99.0.0"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/cat-sis2go-utils/v/99.1.0"
+    }
+  ],
+  "credits": [
+    {
+      "name": "OGAREE",
+      "type": "FINDER",
+      "contact": [
+        "https://github.com/OGAREE"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "urls": [
+        "https://webhook.site/d22d92dc-84e5-4b58-8cd6-75bf1ac452c7"
+      ],
+      "domains": [
+        "webhook.site",
+        "dnshook.site",
+        "d22d92dc-84e5-4b58-8cd6-75bf1ac452c7.dnshook.site"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a report for `cat-sis2go-utils` (npm), versions 99.0.0 and 99.1.0. Both versions are still live on the registry.

The package ships no library code — `index.js` is an 87-byte stub whose own note reads "cat-sis2go-utils dependency-confusion PoC shim". The only executable content is the install payload: `package.json` declares both `preinstall` and `postinstall` running `node scripts/run.js`, which resolves a DNS canary under `dnshook.site` and POSTs to a `webhook.site` collector. 99.0.0 sends only a static marker; 99.1.0, published four minutes later, adds `os.userInfo().username` and `os.hostname()`.

The name combines `cat-` with `sis2go`, matching Caterpillar's SIS2GO product, and the versions are inflated to 99.x. Whether a private package under this name exists could not be verified from public data, so the report states that limitation rather than asserting it.

The package self-identifies as a proof of concept and the author field carries a wearehackerone.com address. It is submitted under the "security researcher activity" and "dependency and manifest confusion" scope items, on the same basis as the existing `box-sign-client` report, since the beacon fires on any install that resolves the package.

Report includes per-file SHA-256 digests, tarball SHA-1/SHA-256/SHA-512-SRI, and the observed IoCs. `id` and `summary` are omitted per CONTRIBUTING.
