### PR TITLE
Add OSV report: toga-ai@1.0.787 — unauthorized telemetry injection via postinstall

### DIFF
--- a/osv/malicious/npm/toga-ai/MAL-0000-toga-ai.json
+++ b/osv/malicious/npm/toga-ai/MAL-0000-toga-ai.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.7.4",
+  "modified": "2026-09-10T00:00:00Z",
+  "published": "2026-09-10T00:00:00Z",
+  "details": "toga-ai@1.0.787 declares an npm postinstall lifecycle hook (`node scripts/install.js --post-install`). By default, the hook writes or updates the user's global `~/.claude/settings.json` without interactive consent. It installs 20 managed telemetry environment variables, including `CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_LOG_USER_PROMPTS=1`, `OTEL_LOG_ASSISTANT_RESPONSES=1`, and `OTEL_LOG_TOOL_DETAILS=1`, and configures OTLP logs, metrics, and traces for `https://otel.togaiq.com` with a hardcoded Bearer credential. These content-logging settings can cause subsequent supported Claude Code sessions to export user prompts, assistant responses, and tool details to the package-configured external collector.\n\nThe script removes existing values for all managed keys and replaces them with its defaults, so reinstalling the package changes user-disabled values such as `OTEL_LOG_USER_PROMPTS=0` back to `1`. `TOGA_SKIP_TELEMETRY=1` skips a later write but does not remove settings written by an earlier install. The package defines no uninstall lifecycle or other removal mechanism to restore the previous global settings.\n\nTrigger and evidence: `package.json` invokes `scripts/install.js` during postinstall; `scripts/install.js:287-307` defines the hardcoded telemetry block, line 326 begins the global settings write path, and line 359 replaces existing managed keys. Static code and data-flow analysis was performed on the published npm tarball without executing package code. SHA-256 of `toga-ai-1.0.787.tgz`: `91b175cc05deefe1c672ce973b8a46b072df0eb91559a3eae03c962d338f3d86`.",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "npm",
+        "name": "toga-ai",
+        "purl": "pkg:npm/toga-ai"
+      },
+      "versions": [
+        "1.0.787"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "PACKAGE",
+      "url": "https://www.npmjs.com/package/toga-ai/v/1.0.787"
+    }
+  ],
+  "credits": [
+    {
+      "name": "smiling-hyena",
+      "type": "FINDER",
+      "contact": [
+        "mailto:smilinghyena4@gmail.com"
+      ]
+    }
+  ],
+  "database_specific": {
+    "iocs": {
+      "domains": [
+        "otel.togaiq.com"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds the malicious npm package `toga-ai@1.0.787`. Not previously in OSV; reported to npm Security on 2026-09-10.

It poses as a Claude Code AI harness but, by default, modifies the user's global `~/.claude/settings.json` during `npm install` through a postinstall hook. It injects 20 managed telemetry environment variables that enable Claude telemetry and content logging for user prompts, assistant responses, and tool execution details. It configures logs, metrics, and traces for the package-configured external collector at `https://otel.togaiq.com` using a hardcoded Bearer credential (`scripts/install.js:291`; credential omitted).

The script removes existing values for its managed telemetry keys before writing its defaults. Reinstalling therefore changes previously user-disabled values such as `OTEL_LOG_USER_PROMPTS=0` back to `1` (`scripts/install.js:359`). `TOGA_SKIP_TELEMETRY=1` prevents a later write but does not remove settings from an earlier installation. The package defines no uninstall lifecycle or other removal mechanism to restore the previous global settings.

The trigger is `package.json` → `node scripts/install.js --post-install`. `applyTelemetryEnv()` defines the hardcoded telemetry block at `scripts/install.js:287-307` and writes the global settings file through the path beginning at line 326. Because the target is the user-level Claude settings file, the configuration can affect subsequent supported Claude Code sessions outside the project in which the npm package was installed. Single affected version: `1.0.787`.

Analysis was static (code and data flow) on the published npm tarball; package code was not executed. Actual conversation transmission was not attempted or confirmed. SHA-256: `91b175cc05deefe1c672ce973b8a46b072df0eb91559a3eae03c962d338f3d86`.
